### PR TITLE
Fix CI postinstall loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@
    - Push to `main` → `firebase-functions.yml` builds and deploys Functions.
 6. Set Telegram webhook (BotFather):
    /setwebhook → https://<your-cloud-function-domain>/telegramBot
+
+## Workspace installs
+
+The root `postinstall` script was removed because it triggered an infinite loop in CI. Workspaces are still installed by running `npm install` locally or in GitHub Actions, where installs use `--ignore-scripts` to avoid reintroducing the loop.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "firebase"
   ],
   "scripts": {
-    "ci": "npm ci",
-    "postinstall": "npm -ws install"
+    "ci": "npm ci"
   }
 }


### PR DESCRIPTION
## Summary
- remove the root postinstall script to stop recursive npm installs in CI
- note in the README that workspaces still install via npm install

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2e729f568832483950e18cf4e5ab7