### PR TITLE
feat(web): migrate to React Router v6; fix Functions typings

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,12 +12,11 @@
     "firebase": "^10.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.2"
+    "react-router-dom": "^6.26.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
-    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^4.2.1",
     "typescript": "^5.3.3",
     "vite": "^5.0.11"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -17,6 +17,7 @@ const App = () => {
           <Route path="/shopping" element={<Shopping user={user} />} />
           <Route path="/calendar" element={<Calendar user={user} />} />
           <Route path="/budget" element={<Budget user={user} />} />
+          <Route path="*" element={<Navigate to="/shopping" replace />} />
         </Routes>
       </main>
     </div>

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -19,6 +19,7 @@ const Header = () => {
           <NavLink
             key={tab.path}
             to={tab.path}
+            end
             className={({ isActive }) =>
               `header-tab ${isActive ? 'header-tab-active' : ''}`
             }

--- a/firebase/functions.ts
+++ b/firebase/functions.ts
@@ -1,12 +1,10 @@
-// firebase/functions.ts
 import { onRequest } from "firebase-functions/v2/https";
 import * as logger from "firebase-functions/logger";
 import { Telegraf, Markup } from "telegraf";
-import type { Update } from "telegraf/types";
 
 const {
   BOT_TOKEN,
-  BOT_USERNAME, // можно хранить для информации, но в конструктор не передаём
+  BOT_USERNAME,
   FAMILY_CHAT_ID,
   WEBAPP_BASE_URL,
   WEBAPP_SHOPPING_URL,
@@ -15,10 +13,8 @@ const {
   NOTIFY_API_KEY,
 } = process.env;
 
-// Создаём бота ТОЛЬКО если есть токен, без лишних опций (username сюда не передают)
-const bot = BOT_TOKEN ? new Telegraf<Update>(BOT_TOKEN) : (null as unknown as Telegraf<Update>);
+const bot = BOT_TOKEN ? new Telegraf(BOT_TOKEN) : null;
 
-// Кнопки веб-аппов
 const menu = () =>
   Markup.inlineKeyboard([
     [Markup.button.webApp("🛒 Покупки", WEBAPP_SHOPPING_URL || `${WEBAPP_BASE_URL}/#/shopping`)],
@@ -26,24 +22,21 @@ const menu = () =>
     [Markup.button.webApp("💰 Бюджет", WEBAPP_BUDGET_URL || `${WEBAPP_BASE_URL}/#/budget`)],
   ]);
 
-// Хэндлеры
-if (BOT_TOKEN) {
+if (bot) {
   bot.start(async (ctx) => ctx.reply("Семейный бот — выберите раздел:", menu()));
   bot.hears(/меню|menu|главное/i, async (ctx) => ctx.reply("Меню:", menu()));
 }
 
-// HTTPS-вебхук Telegram
 export const telegramBot = onRequest({ cors: true }, async (req, res) => {
-  if (!BOT_TOKEN) return res.status(500).send("Bot is not configured");
+  if (!bot) return res.status(500).send("Bot is not configured");
   const callback = bot.webhookCallback("/");
   return callback(req as any, res as any);
 });
 
-// Простой эндпоинт уведомлений из фронта
 export const notify = onRequest({ cors: true }, async (req, res) => {
   try {
     if (req.method !== "POST") return res.status(405).send("Method Not Allowed");
-    if (!BOT_TOKEN || !FAMILY_CHAT_ID) return res.status(500).send("Server not configured");
+    if (!bot || !FAMILY_CHAT_ID) return res.status(500).send("Server not configured");
 
     const apiKey = req.header("x-api-key") || req.header("X-API-KEY");
     if (!apiKey || apiKey !== NOTIFY_API_KEY) return res.status(401).send("Unauthorized");

--- a/firebase/package.json
+++ b/firebase/package.json
@@ -11,12 +11,11 @@
     "deploy:functions": "firebase deploy --only functions"
   },
   "dependencies": {
-    "express": "^4.19.2",
     "firebase-functions": "^4.6.1",
     "telegraf": "^4.16.3"
   },
   "devDependencies": {
-    "@types/node": "^20.11.30",
-    "typescript": "^5.3.3"
+    "typescript": "^5.6.3",
+    "@types/node": "^20.11.30"
   }
 }

--- a/firebase/tsconfig.json
+++ b/firebase/tsconfig.json
@@ -5,7 +5,8 @@
     "outDir": "./dist",
     "rootDir": "./",
     "esModuleInterop": true,
-    "strict": true
+    "strict": true,
+    "types": ["node"]
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- [x] upgrade the web app to React Router v6 and remove v5-only type packages
- [x] adjust the app header and routes to follow the v6 navigation APIs
- [x] refresh Firebase Functions typings with the simplified Telegraf setup

## Testing
- npm --workspace apps/web run build *(fails: dependencies cannot be installed because scoped @types packages return 403 in this environment)*
- npm --workspace firebase run build *(fails: missing @types/node due to the same 403 registry restriction)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f893d7a4832499368c914f14162b