### PR TITLE
Switch bot workspace to CommonJS and update scripts

### DIFF
--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -2,7 +2,7 @@
   "name": "family-telegram-bot",
   "version": "0.1.0",
   "private": true,
-  "type": "module",
+  "type": "commonjs",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -1,8 +1,8 @@
 import express from 'express';
 import { Telegraf } from 'telegraf';
 import type { Context } from 'telegraf';
-import { RU, createReplyKeyboard, createWebAppKeyboard, type WebAppUrls } from './menu.js';
-import { createNotifyFamily, type NotifyFamily } from './notify.js';
+import { RU, createReplyKeyboard, createWebAppKeyboard, type WebAppUrls } from './menu';
+import { createNotifyFamily, type NotifyFamily } from './notify';
 
 const requireEnv = (key: keyof NodeJS.ProcessEnv): string => {
   const value = process.env[key];
@@ -14,17 +14,13 @@ const requireEnv = (key: keyof NodeJS.ProcessEnv): string => {
 };
 
 const BOT_TOKEN = requireEnv('BOT_TOKEN');
-const botUsername = process.env.BOT_USERNAME;
-
 const webAppUrls: WebAppUrls = {
   shopping: requireEnv('WEBAPP_SHOPPING_URL'),
   calendar: requireEnv('WEBAPP_CALENDAR_URL'),
   budget: requireEnv('WEBAPP_BUDGET_URL')
 };
 
-const bot = new Telegraf<Context>(BOT_TOKEN, {
-  username: botUsername
-});
+const bot = new Telegraf<Context>(BOT_TOKEN);
 
 const notifyFamily: NotifyFamily = createNotifyFamily(bot.telegram, process.env.FAMILY_CHAT_ID);
 

--- a/apps/bot/tsconfig.json
+++ b/apps/bot/tsconfig.json
@@ -1,16 +1,13 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ES2020",
-    "moduleResolution": "Node",
-    "outDir": "dist",
+    "module": "commonjs",
+    "moduleResolution": "node",
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
     "strict": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "types": ["node"]
+    "outDir": "dist"
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src"]
 }

--- a/scripts/deploy_functions.cmd
+++ b/scripts/deploy_functions.cmd
@@ -7,11 +7,15 @@ echo Deploying Firebase Functions...
 npm run deploy:functions || goto :err
 echo.
 echo DONE: Functions deployed. Check Cloud Functions URLs in the console output.
+echo.
+echo Done. Press any key to close...
 pause
 exit /b 0
 :err
 echo.
 echo FAILED. Did you run `firebase login`, `firebase use family-bot-33940`,
 echo and set secrets (BOT_TOKEN, BOT_USERNAME, FAMILY_CHAT_ID, NOTIFY_API_KEY)?
+echo.
+echo Done. Press any key to close...
 pause
 exit /b 1

--- a/scripts/deploy_web.cmd
+++ b/scripts/deploy_web.cmd
@@ -7,11 +7,15 @@ echo Deploying web to Firebase Hosting...
 npm run deploy:web || goto :err
 echo.
 echo DONE: Web deployed to Firebase Hosting.
+echo.
+echo Done. Press any key to close...
 pause
 exit /b 0
 :err
 echo.
 echo FAILED. Make sure Node 18+ is installed, `firebase-tools` is installed (`npm i -g firebase-tools`),
 echo and you are logged in (`firebase login`) and selected the project (`firebase use family-bot-33940`).
+echo.
+echo Done. Press any key to close...
 pause
 exit /b 1


### PR DESCRIPTION
## Summary
- switch the Telegram bot workspace to CommonJS and update tsconfig to match
- fix local imports and Telegraf initialization to run cleanly under ts-node
- update Windows deploy scripts to print a closing prompt before pausing

## Testing
- npm --workspace apps/bot install
- npm --workspace apps/bot run build
- BOT_TOKEN=foo WEBAPP_SHOPPING_URL=https://example.com/shopping WEBAPP_CALENDAR_URL=https://example.com/calendar WEBAPP_BUDGET_URL=https://example.com/budget npm --workspace apps/bot run start

------
https://chatgpt.com/codex/tasks/task_e_68d42279c6b483248525902b2f9b1c65