### PR TITLE
Refactor Telegram start UI to single WebApp button

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,11 +3,8 @@ BOT_TOKEN=
 BOT_USERNAME=
 FAMILY_CHAT_ID=
 
-# WebApp URLs inside Telegram buttons
-WEBAPP_BASE_URL=
-WEBAPP_SHOPPING_URL=
-WEBAPP_CALENDAR_URL=
-WEBAPP_BUDGET_URL=
+# WebApp URL inside Telegram buttons
+WEBAPP_URL=
 
 # Shared secret for notify HTTPS endpoint
 NOTIFY_API_KEY=

--- a/README.md
+++ b/README.md
@@ -61,5 +61,21 @@ https://api.telegram.org/bot<ВАШ_BOT_TOKEN>/setWebhook?url=https://<firebase-
 - Секреты не заданы: убедитесь, что все четыре секрета существуют в Firebase Functions.
 - Не установлен Node.js 18+: обновите Node до LTS.
 
+## Настройка WebApp URL и проверка интерфейса бота
+- Добавлен единый WebApp-интерфейс. Задайте переменную `WEBAPP_URL` cо ссылкой на продакшен- или локальный WebApp:
+  - Локально — через файл `.env` в корне монорепозитория.
+  - В облаке — командой `firebase functions:secrets:set WEBAPP_URL --data "https://example.com"`.
+- После деплоя проверьте работу бота:
+  1. Отправьте `/start` в Telegram — бот должен ответить одной фразой «Hello! Open the app:» и кнопкой «Open the app».
+  2. Убедитесь, что под полем ввода не осталось старых Reply-клавиатур.
+  3. Откройте меню (≡) в чате — там должна появиться кнопка WebApp с тем же URL.
+
+### Обновлённые файлы
+- `apps/bot/src/index.ts`
+- `apps/bot/src/menu.ts`
+- `apps/bot/src/types.d.ts`
+- `firebase/functions.ts`
+- `.env.example`
+
 ## Как вернуться к CI/CD
 Для возврата к автоматическим деплоям необходимо снова включить биллинг в Firebase и восстановить GitHub Actions workflows (`.github/workflows`). После этого можно настроить токены и секреты для сервис-аккаунта, чтобы автоматические пайплайны снова запускались при пушах в основную ветку.

--- a/README_MANUAL_DEPLOY.md
+++ b/README_MANUAL_DEPLOY.md
@@ -48,6 +48,7 @@ firebase functions:secrets:set <ИМЯ>
 - `BOT_USERNAME` — @username бота (без `@`).
 - `FAMILY_CHAT_ID` — идентификатор семейного чата.
 - `NOTIFY_API_KEY` — ключ, который используется веб-приложением для вызова функции уведомлений.
+- `WEBAPP_URL` — полный URL WebApp (используется для кнопок в интерфейсе Telegram).
 
 > Совет: Можно передать значение напрямую: `firebase functions:secrets:set BOT_TOKEN --data "123:ABC"`.
 

--- a/apps/bot/src/menu.ts
+++ b/apps/bot/src/menu.ts
@@ -2,36 +2,11 @@ import { Markup } from 'telegraf';
 
 export const RU = {
   botTitle: 'Семейный бот',
-  greeting: 'Привет! 👋',
-  description: 'Семейный бот: Покупки, Календарь, Бюджет.',
-  replyPrompt: 'Выберите раздел ниже.',
-  webAppPrompt: 'Откройте нужный раздел внутри Telegram:',
+  greeting: 'Hello! Open the app:',
   notifyFallback: 'Не удалось отправить уведомление семье.',
-  buttons: {
-    shopping: '🛒 Покупки',
-    calendar: '📅 Календарь',
-    budget: '💰 Бюджет'
-  }
+  buttonLabel: 'Open the app',
+  legacyButtons: ['🛒 Покупки', '📅 Календарь', '💰 Бюджет']
 } as const;
 
-export interface WebAppUrls {
-  shopping: string;
-  calendar: string;
-  budget: string;
-}
-
-export const createReplyKeyboard = () =>
-  Markup.keyboard([
-    [RU.buttons.shopping],
-    [RU.buttons.calendar],
-    [RU.buttons.budget]
-  ]).resize();
-
-export const createWebAppKeyboard = (urls: WebAppUrls) =>
-  Markup.inlineKeyboard(
-    [
-      [Markup.button.webApp(RU.buttons.shopping, urls.shopping)],
-      [Markup.button.webApp(RU.buttons.calendar, urls.calendar)],
-      [Markup.button.webApp(RU.buttons.budget, urls.budget)]
-    ]
-  );
+export const createWebAppKeyboard = (url: string) =>
+  Markup.inlineKeyboard([[Markup.button.webApp(RU.buttonLabel, url)]]);

--- a/apps/bot/src/types.d.ts
+++ b/apps/bot/src/types.d.ts
@@ -3,10 +3,7 @@ declare namespace NodeJS {
     BOT_TOKEN?: string;
     BOT_USERNAME?: string;
     FAMILY_CHAT_ID?: string;
-    WEBAPP_BASE_URL?: string;
-    WEBAPP_SHOPPING_URL?: string;
-    WEBAPP_CALENDAR_URL?: string;
-    WEBAPP_BUDGET_URL?: string;
+    WEBAPP_URL?: string;
     NOTIFY_API_KEY?: string;
     PORT?: string;
     NODE_ENV?: string;


### PR DESCRIPTION
## Summary
- show a single inline WebApp entry on /start, hide legacy reply keyboards, and set the persistent menu button
- consolidate WebApp configuration behind WEBAPP_URL and remove reply keyboard helpers
- document WEBAPP_URL setup, updated env example, and deployment notes

## Testing
- npm --workspace apps/bot run build
- npm --workspace firebase run build

------
https://chatgpt.com/codex/tasks/task_e_68d4c937aa888324ae02ed9774455bc9