### PR TITLE
Add Firebase Hosting CI/CD for web app

### DIFF
--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -1,0 +1,42 @@
+name: Web Preview Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'apps/web/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'firebase.json'
+      - '.github/workflows/web-preview.yml'
+
+jobs:
+  preview:
+    name: Build and Preview Deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build web app
+        run: npm --workspace apps/web run build
+
+      - name: Deploy to Firebase Hosting preview channel
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          projectId: family-bot-33940
+          channelId: pr-${{ github.event.pull_request.number }}
+          expires: 7d
+

--- a/.github/workflows/web-prod.yml
+++ b/.github/workflows/web-prod.yml
@@ -1,0 +1,41 @@
+name: Web Production Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/web/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'firebase.json'
+      - '.github/workflows/web-prod.yml'
+
+jobs:
+  deploy:
+    name: Build and Deploy to Production
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build web app
+        run: npm --workspace apps/web run build
+
+      - name: Deploy to Firebase Hosting (production)
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          projectId: family-bot-33940
+          channelId: live
+

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@
   npm run deploy:all
   ```
 
+## CI/CD для веб-приложения
+- **Секреты:** GitHub Action использует секрет `FIREBASE_SERVICE_ACCOUNT` с JSON сервисного аккаунта Firebase для проекта `family-bot-33940`.
+- **Триггеры:**
+  - pull request (opened/synchronize/reopened) → сборка `apps/web` и выкладка во временный preview-канал Firebase Hosting с автоматическим комментарием в PR.
+  - push в `main` (при изменениях в `apps/web/**`, корневых `package.json`/`package-lock.json`, `firebase.json` и самом workflow) → сборка `apps/web` и деплой на `family-bot-33940.web.app`.
+- **Как отключить или скорректировать:**
+  - Чтобы временно отключить превью, закомментируйте или удалите блок `pull_request` в `.github/workflows/web-preview.yml`.
+  - Чтобы изменить, какие изменения запускают прод-выкладку, обновите список путей в секции `on.push.paths` файла `.github/workflows/web-prod.yml`.
+
 ## Установка вебхука Telegram
 Настройте вебхук через BotFather (`/setwebhook`) или напрямую запросом вида:
 ```


### PR DESCRIPTION
## Summary
- add a pull-request preview workflow that builds apps/web and deploys to a Firebase Hosting preview channel
- add a production workflow that deploys apps/web to the live Firebase Hosting site on pushes to main
- document the new CI/CD automation and related secrets in the README

## Testing
- npm --workspace apps/web run build

------
https://chatgpt.com/codex/tasks/task_e_68d5528a372483249c9fdea07e27837c