### PR TITLE
feat: redesign shopping page with board layout

### DIFF
--- a/apps/web/src/components/ShoppingBoard.tsx
+++ b/apps/web/src/components/ShoppingBoard.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import ShoppingModal from './ShoppingModal';
+
+interface ShoppingItem {
+  id: string;
+  title: string;
+  done: boolean;
+}
+
+interface ShoppingColumn {
+  id: string;
+  title: string;
+  items: ShoppingItem[];
+}
+
+interface ShoppingModalState {
+  isOpen: boolean;
+  listId: string;
+  title: string;
+}
+
+const createInitialItems = (columnIndex: number): ShoppingItem[] =>
+  Array.from({ length: 20 }, (_, index) => {
+    const id = `list-${columnIndex + 1}-item-${index + 1}`;
+    const title = `Продукт ${index + 1}`;
+    const done = (index + columnIndex) % 3 === 0 || index % 5 === 0;
+
+    return { id, title, done };
+  });
+
+const createInitialColumns = (): ShoppingColumn[] => [
+  { id: 'list-1', title: 'Список 1', items: createInitialItems(0) },
+  { id: 'list-2', title: 'Список 2', items: createInitialItems(1) },
+  { id: 'list-3', title: 'Список 3', items: createInitialItems(2) },
+];
+
+const ShoppingBoard = () => {
+  const [columns, setColumns] = useState<ShoppingColumn[]>(() => createInitialColumns());
+  const [modalState, setModalState] = useState<ShoppingModalState>({
+    isOpen: false,
+    listId: 'list-1',
+    title: '',
+  });
+
+  const openModal = () => {
+    setModalState({
+      isOpen: true,
+      listId: columns[0]?.id ?? 'list-1',
+      title: '',
+    });
+  };
+
+  const closeModal = () => {
+    setModalState((state) => ({ ...state, isOpen: false, title: '' }));
+  };
+
+  const handleAddItem = () => {
+    const trimmedTitle = modalState.title.trim();
+    if (!trimmedTitle) {
+      return;
+    }
+
+    setColumns((prevColumns) =>
+      prevColumns.map((column) => {
+        if (column.id !== modalState.listId) {
+          return column;
+        }
+
+        const newItem: ShoppingItem = {
+          id: `${column.id}-item-${column.items.length + 1}-${Date.now()}`,
+          title: trimmedTitle,
+          done: false,
+        };
+
+        return {
+          ...column,
+          items: [...column.items, newItem],
+        };
+      })
+    );
+
+    setModalState((state) => ({ ...state, isOpen: false, title: '' }));
+  };
+
+  return (
+    <div className="shopping-board">
+      <div className="shopping-columns">
+        {columns.map((column) => (
+          <div key={column.id} className="shopping-column">
+            <div className="shopping-column-title">{column.title}</div>
+            <ul className="shopping-items">
+              {column.items.map((item) => (
+                <li key={item.id} className="shopping-item">
+                  <span className={`shopping-item-icon ${item.done ? 'done' : 'pending'}`}>
+                    {item.done ? '✔' : '−'}
+                  </span>
+                  <span className="shopping-item-title">{item.title}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+
+      <button type="button" className="shopping-add-button" onClick={openModal}>
+        Добавить
+      </button>
+
+      <ShoppingModal
+        isOpen={modalState.isOpen}
+        listId={modalState.listId}
+        title={modalState.title}
+        listOptions={columns.map((column) => ({ id: column.id, label: column.title }))}
+        onListChange={(listId) => setModalState((state) => ({ ...state, listId }))}
+        onTitleChange={(title) => setModalState((state) => ({ ...state, title }))}
+        onClose={closeModal}
+        onSubmit={handleAddItem}
+      />
+    </div>
+  );
+};
+
+export default ShoppingBoard;

--- a/apps/web/src/components/ShoppingModal.tsx
+++ b/apps/web/src/components/ShoppingModal.tsx
@@ -1,0 +1,75 @@
+import { FormEvent } from 'react';
+
+interface ShoppingModalProps {
+  isOpen: boolean;
+  listId: string;
+  title: string;
+  listOptions: { id: string; label: string }[];
+  onListChange: (value: string) => void;
+  onTitleChange: (value: string) => void;
+  onClose: () => void;
+  onSubmit: () => void;
+}
+
+const ShoppingModal = ({
+  isOpen,
+  listId,
+  title,
+  listOptions,
+  onListChange,
+  onTitleChange,
+  onClose,
+  onSubmit,
+}: ShoppingModalProps) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onSubmit();
+  };
+
+  const isSubmitDisabled = title.trim().length === 0;
+
+  return (
+    <div className="shopping-modal-overlay" role="dialog" aria-modal="true">
+      <div className="shopping-modal">
+        <h2 className="shopping-modal-title">Добавить продукт</h2>
+        <form className="shopping-modal-form" onSubmit={handleSubmit}>
+          <label className="shopping-modal-field">
+            <span className="shopping-modal-label">В какой список?</span>
+            <select value={listId} onChange={(event) => onListChange(event.target.value)}>
+              {listOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="shopping-modal-field">
+            <span className="shopping-modal-label">Название</span>
+            <input
+              type="text"
+              value={title}
+              onChange={(event) => onTitleChange(event.target.value)}
+              placeholder="Например, яблоки"
+            />
+          </label>
+
+          <div className="shopping-modal-actions">
+            <button type="button" className="shopping-modal-cancel" onClick={onClose}>
+              Отмена
+            </button>
+            <button type="submit" className="shopping-modal-submit" disabled={isSubmitDisabled}>
+              Добавить
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ShoppingModal;

--- a/apps/web/src/pages/Shopping.tsx
+++ b/apps/web/src/pages/Shopping.tsx
@@ -1,16 +1,14 @@
-import ShoppingList from '../components/ShoppingList';
 import type { BasicUser } from '../services/auth';
+import ShoppingBoard from '../components/ShoppingBoard';
 
 interface ShoppingPageProps {
   user: BasicUser | null;
 }
 
-const Shopping = ({ user }: ShoppingPageProps) => {
+const Shopping = ({ user: _user }: ShoppingPageProps) => {
   return (
     <div className="page shopping-page">
-      <ShoppingList category="food" user={user} />
-      <ShoppingList category="household" user={user} />
-      <ShoppingList category="clothes" user={user} />
+      <ShoppingBoard />
     </div>
   );
 };

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -191,6 +191,183 @@ body.tg-theme-dark .toast-error {
   text-decoration: line-through;
 }
 
+.shopping-board {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.shopping-columns {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  align-items: start;
+}
+
+.shopping-column {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.05);
+}
+
+.shopping-column-title {
+  font-size: 14px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.shopping-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.shopping-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  background: rgba(148, 163, 184, 0.12);
+  font-size: 13px;
+  min-height: 32px;
+}
+
+.shopping-item-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  font-size: 16px;
+}
+
+.shopping-item-icon.done {
+  color: #16a34a;
+}
+
+.shopping-item-icon.pending {
+  color: #ef4444;
+}
+
+.shopping-item-title {
+  flex: 1;
+  line-height: 1.2;
+}
+
+.shopping-add-button {
+  width: 100%;
+  padding: 12px 16px;
+  border: none;
+  border-radius: 12px;
+  background: var(--accent-color);
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.shopping-add-button:hover {
+  background: #1d4ed8;
+}
+
+.shopping-add-button:active {
+  transform: translateY(1px);
+}
+
+.shopping-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  z-index: 1000;
+}
+
+.shopping-modal {
+  background: var(--card-bg);
+  border-radius: 16px;
+  padding: 20px;
+  width: min(360px, 100%);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.15);
+  border: 1px solid var(--border-color);
+}
+
+.shopping-modal-title {
+  margin: 0 0 16px;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.shopping-modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.shopping-modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.shopping-modal-label {
+  font-weight: 600;
+}
+
+.shopping-modal-field select,
+.shopping-modal-field input {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  font-size: 14px;
+  background: var(--card-bg);
+  color: var(--text-color);
+}
+
+.shopping-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.shopping-modal-cancel {
+  padding: 10px 16px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-color);
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.shopping-modal-submit {
+  padding: 10px 16px;
+  border-radius: 10px;
+  border: none;
+  background: var(--accent-color);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.shopping-modal-submit:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
 .check-btn,
 .delete-btn,
 .calendar-actions button {


### PR DESCRIPTION
## Summary
- replace the shopping route content with a three-column board using stub data
- add a reusable modal to append items to local state
- style the board layout, checklist items, add button, and modal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d58138f08083248eaac2f29c2b8001