### PR TITLE
feat: add responsive shopping pager

### DIFF
--- a/apps/web/src/__tests__/Shopping.test.tsx
+++ b/apps/web/src/__tests__/Shopping.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import App from '../App';
+
+const setViewportWidth = (width: number) => {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width
+  });
+  window.dispatchEvent(new Event('resize'));
+};
+
+describe('Shopping page responsive behaviour', () => {
+  beforeEach(() => {
+    setViewportWidth(1024);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows pager and switches lists via dots on mobile screens', () => {
+    setViewportWidth(500);
+
+    render(
+      <MemoryRouter initialEntries={["/shopping"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Еда' })).toBeInTheDocument();
+
+    const firstDot = screen.getByRole('button', { name: 'Перейти к списку 1' });
+    const secondDot = screen.getByRole('button', { name: 'Перейти к списку 2' });
+    expect(firstDot).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(secondDot);
+
+    expect(secondDot).toHaveAttribute('aria-pressed', 'true');
+
+    const track = document.querySelector('.shopping-track') as HTMLElement;
+    expect(track.style.transform).toContain('-100%');
+  });
+
+  it('renders all lists side by side on desktop screens', () => {
+    render(
+      <MemoryRouter initialEntries={["/shopping"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Еда' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Бытовое' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Вещи' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Перейти к списку/i })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/Shopping.css
+++ b/apps/web/src/pages/Shopping.css
@@ -1,0 +1,135 @@
+.shopping-page {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--background-color);
+}
+
+.shopping-header {
+  padding: 24px 20px 12px;
+}
+
+.shopping-title {
+  margin: 0;
+  font-size: clamp(28px, 7vw, 34px);
+  font-weight: 700;
+}
+
+.shopping-mobile {
+  position: relative;
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+  touch-action: pan-y;
+}
+
+.shopping-track {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.3s ease;
+}
+
+.shopping-panel {
+  flex: 1 0 100%;
+  min-width: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 24px 20px 32px;
+  gap: 16px;
+}
+
+.shopping-list-title {
+  margin: 0;
+  font-size: clamp(22px, 6vw, 28px);
+  font-weight: 700;
+}
+
+.shopping-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.shopping-item {
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: var(--surface-color);
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
+  font-weight: 500;
+}
+
+.shopping-dots {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  padding: 12px 0 24px;
+}
+
+.shopping-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(37, 99, 235, 0.25);
+  cursor: pointer;
+  padding: 0;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.shopping-dot:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 3px;
+}
+
+.shopping-dot-active {
+  background: var(--accent-color);
+  transform: scale(1.1);
+}
+
+.shopping-desktop-grid {
+  flex: 1;
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 768px) {
+  .shopping-page {
+    padding: 24px;
+    background: transparent;
+  }
+
+  .shopping-header {
+    padding: 0 0 24px;
+  }
+
+  .shopping-title {
+    font-size: 32px;
+  }
+
+  .shopping-desktop-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .shopping-panel {
+    min-width: 0;
+    padding: 24px 20px;
+    background: var(--surface-color);
+    border-radius: 20px;
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  }
+
+  .shopping-items {
+    overflow-y: auto;
+  }
+
+  .shopping-dots {
+    display: none;
+  }
+}

--- a/apps/web/src/pages/Shopping.tsx
+++ b/apps/web/src/pages/Shopping.tsx
@@ -1,7 +1,208 @@
-const Shopping = () => {
+import type { PointerEvent as ReactPointerEvent } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import './Shopping.css';
+
+type ShoppingListData = {
+  title: string;
+  items: string[];
+};
+
+type ShoppingPagerProps = {
+  lists: ShoppingListData[];
+  currentIndex: number;
+  onIndexChange: (index: number) => void;
+};
+
+type PageDotsProps = {
+  count: number;
+  currentIndex: number;
+  onSelect: (index: number) => void;
+};
+
+const createItems = () => Array.from({ length: 10 }, (_, index) => `Пункт ${index + 1}`);
+
+const LISTS: ShoppingListData[] = [
+  { title: 'Еда', items: createItems() },
+  { title: 'Бытовое', items: createItems() },
+  { title: 'Вещи', items: createItems() }
+];
+
+const ShoppingListView = ({ title, items }: ShoppingListData) => (
+  <div className="shopping-panel">
+    <h2 className="shopping-list-title">{title}</h2>
+    <ul className="shopping-items">
+      {items.map((item) => (
+        <li key={`${title}-${item}`} className="shopping-item">
+          {item}
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+const PageDots = ({ count, currentIndex, onSelect }: PageDotsProps) => {
   return (
-    <section className="centered-page">
-      <h1 className="page-title">Покупки</h1>
+    <div className="shopping-dots" role="tablist" aria-label="Списки покупок">
+      {Array.from({ length: count }, (_, index) => {
+        const isActive = index === currentIndex;
+        return (
+          <button
+            key={index}
+            type="button"
+            className={`shopping-dot${isActive ? ' shopping-dot-active' : ''}`}
+            aria-label={`Перейти к списку ${index + 1}`}
+            aria-pressed={isActive}
+            onClick={() => onSelect(index)}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+const SWIPE_THRESHOLD = 12;
+const VERTICAL_CANCEL_THRESHOLD = 40;
+
+const ShoppingPager = ({ lists, currentIndex, onIndexChange }: ShoppingPagerProps) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const startPointRef = useRef<{ x: number; y: number } | null>(null);
+  const allowSwipeRef = useRef(true);
+
+  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const target = event.currentTarget;
+    if (target.setPointerCapture) {
+      try {
+        target.setPointerCapture(event.pointerId);
+      } catch (error) {
+        // Ignore if pointer capture is not supported
+      }
+    }
+    startPointRef.current = { x: event.clientX, y: event.clientY };
+    allowSwipeRef.current = true;
+  };
+
+  const handlePointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!startPointRef.current || !allowSwipeRef.current) {
+      return;
+    }
+    const deltaX = event.clientX - startPointRef.current.x;
+    const deltaY = event.clientY - startPointRef.current.y;
+    if (Math.abs(deltaY) > Math.abs(deltaX) && Math.abs(deltaY) > SWIPE_THRESHOLD) {
+      allowSwipeRef.current = false;
+    }
+  };
+
+  const finishSwipe = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!startPointRef.current) {
+      return;
+    }
+
+    const deltaX = event.clientX - startPointRef.current.x;
+    const deltaY = event.clientY - startPointRef.current.y;
+
+    const target = event.currentTarget;
+    if (target.releasePointerCapture) {
+      try {
+        target.releasePointerCapture(event.pointerId);
+      } catch (error) {
+        // Ignore if pointer capture is not supported
+      }
+    }
+
+    startPointRef.current = null;
+
+    if (!allowSwipeRef.current) {
+      return;
+    }
+
+    if (Math.abs(deltaX) >= SWIPE_THRESHOLD && Math.abs(deltaY) < VERTICAL_CANCEL_THRESHOLD) {
+      if (deltaX < 0) {
+        onIndexChange(Math.min(lists.length - 1, currentIndex + 1));
+      } else if (deltaX > 0) {
+        onIndexChange(Math.max(0, currentIndex - 1));
+      }
+    }
+  };
+
+  const handlePointerCancel = () => {
+    startPointRef.current = null;
+    allowSwipeRef.current = true;
+  };
+
+  const trackStyle = useMemo(
+    () => ({
+      transform: `translateX(-${currentIndex * 100}%)`
+    }),
+    [currentIndex]
+  );
+
+  return (
+    <div
+      ref={containerRef}
+      className="shopping-mobile"
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={finishSwipe}
+      onPointerCancel={handlePointerCancel}
+    >
+      <div className="shopping-track" style={trackStyle}>
+        {lists.map((list) => (
+          <ShoppingListView key={list.title} {...list} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const Shopping = () => {
+  const [isDesktop, setIsDesktop] = useState<boolean>(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+    return window.innerWidth >= 768;
+  });
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handleResize = () => {
+      setIsDesktop(window.innerWidth >= 768);
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  useEffect(() => {
+    if (isDesktop) {
+      setCurrentIndex(0);
+    }
+  }, [isDesktop]);
+
+  return (
+    <section className="shopping-page">
+      <header className="shopping-header">
+        <h1 className="shopping-title">Покупки</h1>
+      </header>
+      {isDesktop ? (
+        <div className="shopping-desktop-grid" aria-label="Списки покупок">
+          {LISTS.map((list) => (
+            <ShoppingListView key={list.title} {...list} />
+          ))}
+        </div>
+      ) : (
+        <>
+          <ShoppingPager
+            lists={LISTS}
+            currentIndex={currentIndex}
+            onIndexChange={setCurrentIndex}
+          />
+          <PageDots count={LISTS.length} currentIndex={currentIndex} onSelect={setCurrentIndex} />
+        </>
+      )}
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- implement a swipe-enabled pager for the shopping lists with three stubbed categories
- add responsive styling to show a single panel on mobile and three columns on desktop
- add tests verifying the pager dots and desktop rendering behaviour

## Testing
- npm --workspace apps/web test

------
https://chatgpt.com/codex/tasks/task_e_68d8c2e4d7cc8324ba27fd73db9ba436