### PR TITLE
Remove in-page shopping tabs

### DIFF
--- a/apps/web/src/pages/Shopping.css
+++ b/apps/web/src/pages/Shopping.css
@@ -7,7 +7,7 @@
 }
 
 .shopping-header {
-  padding: 24px 20px 12px;
+  padding: 24px 20px 0;
 }
 
 .shopping-title {
@@ -67,37 +67,6 @@
   font-weight: 500;
 }
 
-.shopping-tabs {
-  display: flex;
-  gap: 10px;
-  padding: 0 20px 12px;
-}
-
-.shopping-tab {
-  flex: 1;
-  min-width: 0;
-  padding: 10px 14px;
-  border: none;
-  border-radius: 14px;
-  background: rgba(37, 99, 235, 0.08);
-  color: var(--text-color);
-  font-size: clamp(14px, 3.8vw, 16px);
-  font-weight: 600;
-  text-align: center;
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
-}
-
-.shopping-tab:focus-visible {
-  outline: 2px solid var(--accent-color);
-  outline-offset: 2px;
-}
-
-.shopping-tab-active {
-  background: var(--accent-color);
-  color: #ffffff;
-  transform: translateY(-1px);
-}
-
 .shopping-dots {
   display: flex;
   justify-content: center;
@@ -136,10 +105,6 @@
   .shopping-page {
     padding: 24px;
     background: transparent;
-  }
-
-  .shopping-tabs {
-    display: none;
   }
 
   .shopping-header {

--- a/apps/web/src/pages/Shopping.tsx
+++ b/apps/web/src/pages/Shopping.tsx
@@ -77,7 +77,6 @@ type GestureState = {
 
 const ShoppingPager = ({ lists, currentIndex, onIndexChange }: ShoppingPagerProps) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const tabBarRef = useRef<HTMLDivElement | null>(null);
   const gestureStateRef = useRef<GestureState>({
     pointerId: null,
     startX: 0,
@@ -114,11 +113,6 @@ const ShoppingPager = ({ lists, currentIndex, onIndexChange }: ShoppingPagerProp
 
   const handlePointerDownCapture = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.pointerType === 'mouse') {
-      return;
-    }
-
-    const targetNode = event.target as Node | null;
-    if (targetNode && tabBarRef.current?.contains(targetNode)) {
       return;
     }
 
@@ -271,44 +265,20 @@ const ShoppingPager = ({ lists, currentIndex, onIndexChange }: ShoppingPagerProp
   );
 
   return (
-    <>
-      <div
-        ref={tabBarRef}
-        className="shopping-tabs"
-        role="tablist"
-        aria-label="Категории покупок"
-      >
-        {lists.map((list, index) => {
-          const isActive = index === currentIndex;
-          return (
-            <button
-              key={list.title}
-              type="button"
-              role="tab"
-              className={`shopping-tab${isActive ? ' shopping-tab-active' : ''}`}
-              aria-selected={isActive}
-              onClick={() => onIndexChange(index)}
-            >
-              {list.title}
-            </button>
-          );
-        })}
+    <div
+      ref={containerRef}
+      className="shopping-mobile"
+      onPointerDownCapture={handlePointerDownCapture}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerEnd}
+      onPointerCancel={handlePointerCancel}
+    >
+      <div className="shopping-track" style={trackStyle}>
+        {lists.map((list) => (
+          <ShoppingListView key={list.title} {...list} />
+        ))}
       </div>
-      <div
-        ref={containerRef}
-        className="shopping-mobile"
-        onPointerDownCapture={handlePointerDownCapture}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerEnd}
-        onPointerCancel={handlePointerCancel}
-      >
-        <div className="shopping-track" style={trackStyle}>
-          {lists.map((list) => (
-            <ShoppingListView key={list.title} {...list} />
-          ))}
-        </div>
-      </div>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- remove the in-page shopping category tabs so the pager relies on swipes only
- tidy the shopping page spacing after removing the segmented control

## Testing
- npm --workspace apps/web run test

------
https://chatgpt.com/codex/tasks/task_e_68d8f9a4239c83249e64ee4d81d36b5e