### PR TITLE
Update shopping header and swipe interactions

### DIFF
--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -11,9 +11,12 @@ describe('App routes', () => {
       </MemoryRouter>
     );
 
-  it('renders shopping page title', () => {
+  it('renders shopping current list heading', () => {
     renderWithRoute('/shopping');
-    expect(screen.getByRole('heading', { level: 1, name: 'Покупки' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Еда' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Покупки' })
+    ).not.toBeInTheDocument();
   });
 
   it('renders calendar page title', () => {

--- a/apps/web/src/__tests__/Shopping.test.tsx
+++ b/apps/web/src/__tests__/Shopping.test.tsx
@@ -30,7 +30,7 @@ describe('Shopping page responsive behaviour', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByRole('heading', { level: 2, name: 'Еда' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Еда' })).toBeInTheDocument();
 
     const firstDot = screen.getByRole('button', { name: 'Перейти к списку 1' });
     const secondDot = screen.getByRole('button', { name: 'Перейти к списку 2' });

--- a/apps/web/src/pages/Shopping.css
+++ b/apps/web/src/pages/Shopping.css
@@ -7,12 +7,12 @@
 }
 
 .shopping-header {
-  padding: 24px 20px 0;
+  padding: 16px 20px 0;
 }
 
-.shopping-title {
+.shopping-current-title {
   margin: 0;
-  font-size: clamp(28px, 7vw, 34px);
+  font-size: clamp(24px, 6vw, 30px);
   font-weight: 700;
 }
 
@@ -108,11 +108,7 @@
   }
 
   .shopping-header {
-    padding: 0 0 24px;
-  }
-
-  .shopping-title {
-    font-size: 32px;
+    display: none;
   }
 
   .shopping-desktop-grid {

--- a/apps/web/src/pages/Shopping.tsx
+++ b/apps/web/src/pages/Shopping.tsx
@@ -7,6 +7,10 @@ type ShoppingListData = {
   items: string[];
 };
 
+type ShoppingListViewProps = ShoppingListData & {
+  showTitle?: boolean;
+};
+
 type ShoppingPagerProps = {
   lists: ShoppingListData[];
   currentIndex: number;
@@ -27,9 +31,9 @@ const LISTS: ShoppingListData[] = [
   { title: 'Вещи', items: createItems() }
 ];
 
-const ShoppingListView = ({ title, items }: ShoppingListData) => (
+const ShoppingListView = ({ title, items, showTitle = true }: ShoppingListViewProps) => (
   <div className="shopping-panel">
-    <h2 className="shopping-list-title">{title}</h2>
+    {showTitle ? <h2 className="shopping-list-title">{title}</h2> : null}
     <ul className="shopping-items">
       {items.map((item) => (
         <li key={`${title}-${item}`} className="shopping-item">
@@ -113,6 +117,11 @@ const ShoppingPager = ({ lists, currentIndex, onIndexChange }: ShoppingPagerProp
 
   const handlePointerDownCapture = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.pointerType === 'mouse') {
+      return;
+    }
+
+    const topNav = document.querySelector('.top-tabs');
+    if (topNav && topNav.contains(event.target as Node)) {
       return;
     }
 
@@ -217,6 +226,7 @@ const ShoppingPager = ({ lists, currentIndex, onIndexChange }: ShoppingPagerProp
       } catch (error) {
         // Ignore release errors
       }
+      state.hasPointerCapture = false;
     }
 
     if (!state.longPressActive && !state.isVerticalScroll) {
@@ -252,6 +262,7 @@ const ShoppingPager = ({ lists, currentIndex, onIndexChange }: ShoppingPagerProp
       } catch (error) {
         // Ignore release errors
       }
+      state.hasPointerCapture = false;
     }
 
     resetGestureState();
@@ -275,7 +286,7 @@ const ShoppingPager = ({ lists, currentIndex, onIndexChange }: ShoppingPagerProp
     >
       <div className="shopping-track" style={trackStyle}>
         {lists.map((list) => (
-          <ShoppingListView key={list.title} {...list} />
+          <ShoppingListView key={list.title} {...list} showTitle={false} />
         ))}
       </div>
     </div>
@@ -310,10 +321,14 @@ const Shopping = () => {
     }
   }, [isDesktop]);
 
+  const currentList = LISTS[currentIndex];
+
   return (
     <section className="shopping-page">
       <header className="shopping-header">
-        <h1 className="shopping-title">Покупки</h1>
+        {!isDesktop && (
+          <h1 className="shopping-current-title">{currentList.title}</h1>
+        )}
       </header>
       {isDesktop ? (
         <div className="shopping-desktop-grid" aria-label="Списки покупок">


### PR DESCRIPTION
## Summary
- show the active shopping list title directly beneath the top navigation while keeping desktop layout intact
- update the shopping pager to handle swipe gestures from a single wrapper and ignore pointer starts on the top navigation
- refresh related styles and tests to cover the new header behavior

## Testing
- npm --workspace apps/web test

------
https://chatgpt.com/codex/tasks/task_e_68d9018446388324aadb3152e7baba32