### PR TITLE
chore: update lockfile for react-swipeable dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6097,6 +6097,18 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-swipeable": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.1.tgz",
+      "integrity": "sha512-Nux1DPZWS9Vyuk3F7S3w7Dnk3a1JpN96CB2A+qsSVqSdz+CA0nVddOZXS6jttuPAHyBs+K6TfGsDz3jAC5vVsA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",


### PR DESCRIPTION
## Summary
- add the react-swipeable dependency entry to the root package-lock so the apps/web workspace resolves it

## Testing
- npm ci --workspaces *(fails: 403 Forbidden fetching https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.1.tgz in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d90b0ae44c8324b162b8c4eb772bee