### PR TITLE
Fix shopping pager swipe gesture coverage

### DIFF
--- a/apps/web/src/pages/Shopping.css
+++ b/apps/web/src/pages/Shopping.css
@@ -8,6 +8,15 @@
   overscroll-behavior-x: contain;
 }
 
+.shopping-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  touch-action: pan-y;
+  overscroll-behavior-x: contain;
+}
+
 .shopping-header {
   padding: 16px 20px 0;
 }
@@ -59,6 +68,7 @@
   gap: 12px;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
 }
 
 .shopping-item {

--- a/apps/web/src/pages/Shopping.tsx
+++ b/apps/web/src/pages/Shopping.tsx
@@ -99,9 +99,41 @@ const Shopping = () => {
     setCurrentIndex((index) => Math.max(0, index - 1));
   }, []);
 
+  const isSwipeDebugEnabled = useMemo(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+
+    return new URLSearchParams(window.location.search).get('debugSwipe') === '1';
+  }, []);
+
   const swipeHandlers = useSwipeable({
+    onSwipeStart: (eventData) => {
+      if (!isSwipeDebugEnabled) {
+        return;
+      }
+
+      const target = eventData.event?.target as HTMLElement | null;
+      console.log('[shopping] swipe start', target?.tagName ?? 'unknown', eventData);
+    },
+    onSwiping: (eventData) => {
+      if (!isSwipeDebugEnabled) {
+        return;
+      }
+
+      const target = eventData.event?.target as HTMLElement | null;
+      console.log('[shopping] swiping', target?.tagName ?? 'unknown', eventData.dir);
+    },
     onSwipedLeft: () => goToNextPage(),
     onSwipedRight: () => goToPrevPage(),
+    onSwiped: (eventData) => {
+      if (!isSwipeDebugEnabled) {
+        return;
+      }
+
+      const target = eventData.event?.target as HTMLElement | null;
+      console.log('[shopping] swiped', target?.tagName ?? 'unknown', eventData.dir, eventData);
+    },
     delta: 12,
     preventScrollOnSwipe: true,
     trackTouch: true,
@@ -131,10 +163,7 @@ const Shopping = () => {
   const currentList = LISTS[currentIndex];
 
   return (
-    <section
-      className="shopping-page"
-      {...(!isDesktop ? swipeHandlers : {})}
-    >
+    <section className="shopping-page">
       <header className="shopping-header">
         {!isDesktop && (
           <h1 className="shopping-current-title">{currentList.title}</h1>
@@ -147,13 +176,13 @@ const Shopping = () => {
           ))}
         </div>
       ) : (
-        <>
+        <div className="shopping-content" {...swipeHandlers}>
           <ShoppingPager
             lists={LISTS}
             currentIndex={currentIndex}
           />
           <PageDots count={LISTS.length} currentIndex={currentIndex} onSelect={setCurrentIndex} />
-        </>
+        </div>
       )}
     </section>
   );


### PR DESCRIPTION
## Summary
- attach the swipe handlers to a mobile content wrapper that covers the lists so gestures can start on any row
- add touch-action and overscroll-behavior guards on the wrapper and list to keep horizontal swipes from being swallowed by scrolling containers
- add an optional ?debugSwipe=1 logger to inspect swipe event targets during troubleshooting

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da0427149c8324b8b6826e2905386f