### PR TITLE
Implement local checklist state for shopping lists

### DIFF
--- a/apps/web/src/pages/Shopping.css
+++ b/apps/web/src/pages/Shopping.css
@@ -72,11 +72,30 @@
 }
 
 .shopping-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
   padding: 14px 16px;
   border-radius: 16px;
   background: var(--surface-color);
   box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
   font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+}
+
+.shopping-item:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 3px;
+}
+
+.shopping-item-icon {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.shopping-item-title {
+  flex: 1;
 }
 
 .shopping-dots {


### PR DESCRIPTION
## Summary
- convert the shopping lists into local-state checklists with emoji indicators and keyboard/touch toggles
- preserve the swipe pager while wiring the toggle handler through both mobile and desktop layouts
- expand Shopping page tests to cover checklist behaviour, styling, and swipe logging

## Testing
- npm --workspace apps/web test

------
https://chatgpt.com/codex/tasks/task_e_68daaa9e85c08324ab69c26d9cb459bb