### PR TITLE
Fix Shopping page mobile layout centering

### DIFF
--- a/apps/web/src/pages/Shopping.css
+++ b/apps/web/src/pages/Shopping.css
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  min-width: 0;
   background: var(--background-color);
   touch-action: pan-y;
   overscroll-behavior-x: contain;


### PR DESCRIPTION
## Summary
- allow the Shopping page flex container to shrink to the viewport by setting `min-width: 0`
- keep the existing desktop layout while centering the cards and pager dots on mobile

## Testing
- npm --workspace apps/web run test

## Notes
- Previously the `.shopping-page` flex item kept its default `min-width: auto`, so the wide swipe track forced the page to ~476px in a 390px viewport, shifting cards and pager dots off-center. Setting `min-width: 0` lets the container follow the viewport width while leaving desktop unaffected.


------
https://chatgpt.com/codex/tasks/task_e_68dac53e1c3c8324beacfa6363963e92