### PR TITLE
Keep shopping pager dots visible during list scroll

### DIFF
--- a/apps/web/src/pages/Shopping.css
+++ b/apps/web/src/pages/Shopping.css
@@ -31,6 +31,7 @@
 .shopping-mobile {
   position: relative;
   flex: 1;
+  min-height: 0;
   display: flex;
   overflow: hidden;
   touch-action: pan-y;
@@ -48,6 +49,7 @@
 .shopping-panel {
   flex: 1 0 100%;
   min-width: 100%;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -65,10 +67,13 @@
   margin: 0;
   padding: 0;
   display: flex;
+  flex: 1;
+  min-height: 0;
   flex-direction: column;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   touch-action: pan-y;
+  padding-bottom: calc(64px + env(safe-area-inset-bottom));
 }
 
 .check-item {
@@ -109,10 +114,17 @@
 }
 
 .shopping-dots {
+  position: sticky;
+  bottom: 0;
   display: flex;
   justify-content: center;
   gap: 10px;
-  padding: 12px 0 24px;
+  padding: 12px 0 calc(16px + env(safe-area-inset-bottom));
+  background: linear-gradient(
+    to top,
+    var(--background-color) 45%,
+    transparent
+  );
 }
 
 .shopping-dot {


### PR DESCRIPTION
## Summary
- prevent the mobile shopping panels from expanding past the viewport so vertical scrolling happens inside the list instead of pushing the pager away
- keep the page dots sticky with safe-area padding and add list padding so the last item stays tappable while the dots remain visible

## Testing
- npm test -- Shopping *(fails: missing npm "test" script in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68db3c3b591c8324a4e114daf3d5d5a4