### PR TITLE
Add context menu actions to shopping checklist items

### DIFF
--- a/apps/web/src/pages/Shopping.css
+++ b/apps/web/src/pages/Shopping.css
@@ -273,6 +273,115 @@
   background: rgba(229, 231, 235, 0.85);
 }
 
+.shopping-context-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  touch-action: none;
+  background: transparent;
+}
+
+.shopping-context-menu {
+  position: absolute;
+  min-width: 188px;
+  padding: 6px 0;
+  background: var(--surface-color);
+  border-radius: 16px;
+  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.18);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+}
+
+.shopping-context-button {
+  width: 100%;
+  padding: 12px 20px;
+  border: none;
+  background: transparent;
+  text-align: left;
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--text-color);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.shopping-context-button + .shopping-context-button {
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.shopping-context-button:hover,
+.shopping-context-button:focus-visible {
+  background: rgba(37, 99, 235, 0.08);
+  outline: none;
+}
+
+.shopping-context-button:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--accent-color);
+  border-radius: 14px;
+}
+
+.shopping-context-button-danger {
+  color: #dc2626;
+}
+
+.shopping-context-button-danger:hover,
+.shopping-context-button-danger:focus-visible {
+  background: rgba(220, 38, 38, 0.12);
+  color: #b91c1c;
+}
+
+.shopping-rename-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 16px;
+  background: var(--shopping-overlay);
+  backdrop-filter: blur(2px);
+  touch-action: none;
+}
+
+.shopping-rename-modal {
+  width: 100%;
+  max-width: 360px;
+  background: var(--surface-color);
+  border-radius: 18px;
+  padding: 24px 20px;
+  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.18);
+}
+
+.shopping-rename-title {
+  margin: 0 0 12px;
+  font-size: clamp(20px, 5vw, 24px);
+  font-weight: 700;
+}
+
+.shopping-rename-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.shopping-rename-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.shopping-rename-label {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.shopping-rename-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .shopping-dot {
   width: 10px;
   height: 10px;
@@ -341,5 +450,17 @@
 
   .shopping-modal {
     max-width: 360px;
+  }
+
+  .shopping-context-menu {
+    min-width: 200px;
+  }
+
+  .shopping-rename-overlay {
+    padding: 32px;
+  }
+
+  .shopping-rename-modal {
+    max-width: 320px;
   }
 }


### PR DESCRIPTION
## Summary
- add a long-press/right-click context menu for shopping checklist items with rename and delete actions that block swipe and scroll while open
- introduce a compact rename modal that keeps the done flag and re-sorts lists via the existing helper after saving
- style the new context menu and rename modal layers via portals so they render above the scrollable lists without clipping

## Testing
- npm test --prefix apps/web

------
https://chatgpt.com/codex/tasks/task_e_68dc122b3b4c8324af8e76b84107ba45