### PR TITLE
Fix shopping mobile layout jitter and preserve active tab

### DIFF
--- a/apps/web/src/__tests__/Shopping.test.tsx
+++ b/apps/web/src/__tests__/Shopping.test.tsx
@@ -148,4 +148,56 @@ describe('Shopping page responsive behaviour', () => {
     logSpy.mockRestore();
     errorSpy.mockRestore();
   });
+
+  it('keeps the active tab after adding an item on mobile', () => {
+    setViewportWidth(500);
+
+    render(
+      <MemoryRouter initialEntries={["/shopping"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    const secondDot = screen.getByRole('button', { name: 'Перейти к списку 2' });
+    fireEvent.click(secondDot);
+    expect(secondDot).toHaveAttribute('aria-pressed', 'true');
+
+    const lists = screen.getAllByRole('list');
+    const householdPanel = lists[1]?.parentElement as HTMLElement;
+    const addButton = within(householdPanel).getByRole('button', { name: '+ добавить' });
+    fireEvent.click(addButton);
+
+    const titleInput = screen.getByLabelText('Название');
+    fireEvent.change(titleInput, { target: { value: 'Абажур настольный' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Добавить' }));
+
+    expect(secondDot).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('keeps the active tab after renaming an item on mobile', () => {
+    setViewportWidth(500);
+
+    render(
+      <MemoryRouter initialEntries={["/shopping"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    const thirdDot = screen.getByRole('button', { name: 'Перейти к списку 3' });
+    fireEvent.click(thirdDot);
+    expect(thirdDot).toHaveAttribute('aria-pressed', 'true');
+
+    const lists = screen.getAllByRole('list');
+    const thirdList = lists[2];
+    const firstItem = within(thirdList).getAllByRole('button')[0];
+
+    fireEvent.contextMenu(firstItem, { clientX: 100, clientY: 100 });
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Переименовать' }));
+
+    const renameInput = screen.getByLabelText('Название');
+    fireEvent.change(renameInput, { target: { value: 'Новый плед' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Сохранить' }));
+
+    expect(thirdDot).toHaveAttribute('aria-pressed', 'true');
+  });
 });

--- a/apps/web/src/pages/shopping/ShoppingLayout.module.css
+++ b/apps/web/src/pages/shopping/ShoppingLayout.module.css
@@ -32,12 +32,22 @@
   gap: 16px;
   position: relative;
   touch-action: pan-y;
+  align-items: center;
+  min-height: 0;
+  width: 100%;
+  padding-bottom: 0;
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 .mobileTrackWrapper {
   overflow: hidden;
   border-radius: calc(var(--app-radius) + 6px);
   background: transparent;
+  width: 100%;
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  max-width: 520px;
 }
 
 .mobileTrack {
@@ -45,12 +55,36 @@
   width: 100%;
   transition: transform 0.25s ease;
   will-change: transform;
+  height: 100%;
 }
 
 .mobilePanel {
   flex: 0 0 100%;
   padding-right: 16px;
   padding-left: 16px;
+  display: flex;
+  justify-content: center;
+}
+
+.mobilePanelInner {
+  flex: 1;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+}
+
+.mobileFooter {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 0 16px 12px 16px;
+  padding-bottom: calc(12px + env(safe-area-inset-bottom));
+  box-sizing: border-box;
+}
+.mobileFooterDots {
+  width: 100%;
+  max-width: 520px;
+  margin: 0 auto;
 }
 
 @media (min-width: 768px) {

--- a/apps/web/src/pages/shopping/components/Checklist.module.css
+++ b/apps/web/src/pages/shopping/components/Checklist.module.css
@@ -8,6 +8,8 @@
   box-shadow: var(--app-shadow-low);
   border: 1px solid rgba(15, 23, 42, 0.08);
   min-height: 100%;
+  width: 100%;
+  min-width: 0;
 }
 
 .heading {
@@ -26,4 +28,32 @@
 
 .footer {
   margin-top: auto;
+}
+
+@media (max-width: 767px) {
+  .panel {
+    height: 100%;
+  }
+
+  .items {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding-right: 4px;
+    margin-right: -4px;
+    padding-bottom: 24px;
+  }
+
+  .footer {
+    position: sticky;
+    bottom: 0;
+    background: linear-gradient(
+      180deg,
+      rgba(247, 249, 246, 0) 0%,
+      rgba(247, 249, 246, 0.92) 60%,
+      var(--app-color-surface) 100%
+    );
+    padding-top: 16px;
+    margin-top: 0;
+  }
 }

--- a/apps/web/src/pages/shopping/components/Dialog.tsx
+++ b/apps/web/src/pages/shopping/components/Dialog.tsx
@@ -24,6 +24,28 @@ export const Dialog = ({
       return;
     }
 
+    const { body, documentElement } = document;
+    const previousBodyOverflow = body.style.overflow;
+    const previousBodyPaddingRight = body.style.paddingRight;
+    const previousBodyPosition = body.style.position;
+    const previousBodyTop = body.style.top;
+    const previousBodyWidth = body.style.width;
+    const previousHtmlOverflow = documentElement.style.overflow;
+    const computedBodyPaddingRight = Number.parseFloat(
+      window.getComputedStyle(body).paddingRight || '0'
+    );
+    const scrollbarWidth = window.innerWidth - documentElement.clientWidth;
+    const scrollY = window.scrollY;
+
+    body.style.overflow = 'hidden';
+    documentElement.style.overflow = 'hidden';
+    if (scrollbarWidth > 0) {
+      body.style.paddingRight = `${computedBodyPaddingRight + scrollbarWidth}px`;
+    }
+    body.style.position = 'fixed';
+    body.style.top = `-${scrollY}px`;
+    body.style.width = '100%';
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         event.preventDefault();
@@ -32,7 +54,26 @@ export const Dialog = ({
     };
 
     window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      body.style.overflow = previousBodyOverflow;
+      body.style.paddingRight = previousBodyPaddingRight;
+      body.style.position = previousBodyPosition;
+      body.style.top = previousBodyTop;
+      body.style.width = previousBodyWidth;
+      documentElement.style.overflow = previousHtmlOverflow;
+      if (
+        typeof window !== 'undefined' &&
+        typeof window.scrollTo === 'function' &&
+        scrollY !== 0
+      ) {
+        try {
+          window.scrollTo(0, scrollY);
+        } catch (error) {
+          // Ignore unsupported scroll operations (e.g. in test environments).
+        }
+      }
+    };
   }, [onClose, open]);
 
   if (!open) {

--- a/apps/web/src/pages/shopping/components/PagerDots.module.css
+++ b/apps/web/src/pages/shopping/components/PagerDots.module.css
@@ -1,6 +1,7 @@
 .container {
   position: sticky;
   bottom: 12px;
+  bottom: calc(env(safe-area-inset-bottom) + 12px);
   left: 0;
   width: 100%;
   display: flex;

--- a/apps/web/src/pages/shopping/components/PagerDots.tsx
+++ b/apps/web/src/pages/shopping/components/PagerDots.tsx
@@ -4,11 +4,13 @@ type PagerDotsProps = {
   count: number;
   currentIndex: number;
   onSelect: (index: number) => void;
+  className?: string;
 };
 
-export const PagerDots = ({ count, currentIndex, onSelect }: PagerDotsProps) => {
+export const PagerDots = ({ count, currentIndex, onSelect, className }: PagerDotsProps) => {
+  const containerClassName = [styles.container, className].filter(Boolean).join(' ');
   return (
-    <div className={styles.container} role="tablist" aria-label="Списки покупок">
+    <div className={containerClassName} role="tablist" aria-label="Списки покупок">
       {Array.from({ length: count }, (_, index) => {
         const isActive = index === currentIndex;
         return (


### PR DESCRIPTION
## Summary
- center the mobile shopping panels and footer to stop pager drift, keeping scrolling inside the checklist panel
- lock body scroll while dialogs are open to prevent viewport jumps from scrollbar changes
- track the active list by id so adding or renaming items no longer resets the selected page, and cover it with unit tests

## Testing
- npm --workspace apps/web test

------
https://chatgpt.com/codex/tasks/task_e_68dc7ec70cc88324878ca496b0b7fdf8