### PR TITLE
Fix shopping page width on mobile

### DIFF
--- a/apps/web/src/pages/shopping/ShoppingLayout.module.css
+++ b/apps/web/src/pages/shopping/ShoppingLayout.module.css
@@ -5,6 +5,8 @@
   padding: 16px;
   min-height: calc(100vh - 64px);
   background: var(--app-color-background);
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .header {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -51,6 +51,9 @@ body {
 .page-container {
   flex: 1;
   display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
 }
 
 .centered-page {


### PR DESCRIPTION
## Summary
- ensure the main page container stacks content vertically and stretches to the viewport width
- force the shopping page layout to respect the available width to avoid horizontal overflow on mobile

## Testing
- npm --workspace apps/web run test

------
https://chatgpt.com/codex/tasks/task_e_68dd1c58a0fc8324b15c471fc1e86c6b