### PR TITLE
Fix shopping swipe gesture and prevent mobile keyboard jump

### DIFF
--- a/apps/web/src/pages/Shopping.tsx
+++ b/apps/web/src/pages/Shopping.tsx
@@ -397,6 +397,7 @@ const Shopping = () => {
           onTitleChange={(value) => setAddFormState((prev) => ({ ...prev, title: value }))}
           onSubmit={addItem}
           onCancel={closeAddDialog}
+          autoFocusTitle={isDesktop}
         />
       </Dialog>
 
@@ -412,6 +413,7 @@ const Shopping = () => {
             onChange={(value) => setRenameState((prev) => (prev ? { ...prev, value } : prev))}
             onSubmit={applyRename}
             onCancel={cancelRename}
+            autoFocusInput={isDesktop}
           />
         ) : null}
       </Dialog>

--- a/apps/web/src/pages/shopping/ShoppingLayout.module.css
+++ b/apps/web/src/pages/shopping/ShoppingLayout.module.css
@@ -33,7 +33,6 @@
   flex-direction: column;
   gap: 16px;
   position: relative;
-  touch-action: pan-y;
   align-items: center;
   min-height: 0;
   width: 100%;

--- a/apps/web/src/pages/shopping/components/AddItemForm.tsx
+++ b/apps/web/src/pages/shopping/components/AddItemForm.tsx
@@ -16,6 +16,7 @@ type AddItemFormProps = {
   onTitleChange: (value: string) => void;
   onSubmit: () => void;
   onCancel: () => void;
+  autoFocusTitle?: boolean;
 };
 
 export const AddItemForm = ({
@@ -24,7 +25,8 @@ export const AddItemForm = ({
   onCategoryChange,
   onTitleChange,
   onSubmit,
-  onCancel
+  onCancel,
+  autoFocusTitle = false
 }: AddItemFormProps) => {
   const isSubmitDisabled = useMemo(() => state.title.trim().length === 0, [state.title]);
 
@@ -59,7 +61,7 @@ export const AddItemForm = ({
           value={state.title}
           onChange={(event: ChangeEvent<HTMLInputElement>) => onTitleChange(event.target.value)}
           placeholder="Что добавить?"
-          autoFocus
+          autoFocus={autoFocusTitle}
           required
         />
       </div>

--- a/apps/web/src/pages/shopping/components/RenameItemForm.tsx
+++ b/apps/web/src/pages/shopping/components/RenameItemForm.tsx
@@ -8,9 +8,16 @@ type RenameItemFormProps = {
   onChange: (value: string) => void;
   onSubmit: () => void;
   onCancel: () => void;
+  autoFocusInput?: boolean;
 };
 
-export const RenameItemForm = ({ value, onChange, onSubmit, onCancel }: RenameItemFormProps) => {
+export const RenameItemForm = ({
+  value,
+  onChange,
+  onSubmit,
+  onCancel,
+  autoFocusInput = false
+}: RenameItemFormProps) => {
   const isDisabled = value.trim().length === 0;
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -27,7 +34,7 @@ export const RenameItemForm = ({ value, onChange, onSubmit, onCancel }: RenameIt
         label="Название"
         value={value}
         onChange={(event: ChangeEvent<HTMLInputElement>) => onChange(event.target.value)}
-        autoFocus
+        autoFocus={autoFocusInput}
         required
       />
       <div className={styles.actions}>


### PR DESCRIPTION
## Summary
- restore horizontal swiping between shopping lists by letting the track receive touch events again
- avoid the mobile keyboard popping up with dialogs by only auto-focusing fields on desktop

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd328e76dc83249322e1dcba545d52