### PR TITLE
web(shopping): restore swipe gestures and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ https://api.telegram.org/bot<ВАШ_BOT_TOKEN>/setWebhook?url=https://<firebase-
 - `npm --workspace apps/web run preview` — предпросмотр production-сборки.
 - `npm --workspace apps/web run test` — прогонит vitest и smoke-тесты маршрутов.
 
+### Gesture notes (apps/web)
+- Страница покупок использует `useSwipeable` с опциями `preventScrollOnSwipe: true`, `trackMouse: true` и `delta: 12`, чтобы обеспечить плавные горизонтальные свайпы и сохранить вертикальный скролл списков.
+- Контейнер `.mobileContent` получает `touch-action: pan-y`, поэтому вертикальные жесты работают внутри чеклистов, а горизонтальные передаются свайперу.
+- Для проверки жестов выполните `npm --workspace apps/web run test` — добавлены unit-тесты, моделирующие горизонтальные и вертикальные свайпы, а также клики и работу на границах.
+
 ### Маршруты
 Приложение использует `HashRouter` и открывается с вкладки «Покупки».
 - `#/shopping` — страница «Покупки» с единственным заголовком «Покупки» по центру.

--- a/apps/web/src/pages/Shopping.tsx
+++ b/apps/web/src/pages/Shopping.tsx
@@ -83,6 +83,7 @@ const Shopping = () => {
   const [renameState, setRenameState] = useState<RenameState | null>(null);
 
   const listCount = lists.length;
+  // apps/web/src/pages/Shopping.tsx: currentIndex mirrors the horizontal pager position for swipe gestures.
   const currentIndex = useMemo(() => {
     if (listCount === 0) {
       return 0;
@@ -286,6 +287,7 @@ const Shopping = () => {
     return new URLSearchParams(window.location.search).get('debugSwipe') === '1';
   }, []);
 
+  // apps/web/src/pages/Shopping.tsx: mobileContent (see render) spans the full swipe surface, so handlers live here.
   const swipeHandlers = useSwipeable({
     onSwipeStart: (eventData) => {
       if (!isSwipeDebugEnabled) {
@@ -303,10 +305,18 @@ const Shopping = () => {
       const target = eventData.event?.target as HTMLElement | null;
       console.log('[shopping] swiping', target?.tagName ?? 'unknown', eventData.dir);
     },
-    onSwipedLeft: () =>
-      selectListByIndex(Math.min(Math.max(listCount - 1, 0), currentIndex + 1)),
-    onSwipedRight: () =>
-      selectListByIndex(Math.max(0, currentIndex - 1)),
+    onSwipedLeft: () => {
+      if (currentIndex >= listCount - 1) {
+        return;
+      }
+      selectListByIndex(currentIndex + 1);
+    },
+    onSwipedRight: () => {
+      if (currentIndex <= 0) {
+        return;
+      }
+      selectListByIndex(currentIndex - 1);
+    },
     onSwiped: (eventData) => {
       if (!isSwipeDebugEnabled) {
         return;
@@ -318,6 +328,7 @@ const Shopping = () => {
     delta: 12,
     preventScrollOnSwipe: true,
     trackTouch: true,
+    trackMouse: true,
     touchEventOptions: { passive: false },
     rotationAngle: 0
   });
@@ -354,11 +365,25 @@ const Shopping = () => {
           ))}
         </div>
       ) : (
-        <div className={`${styles.mobileContent} shopping-content`} {...swipeHandlers}>
+        // apps/web/src/pages/Shopping.tsx: handlers live on mobileContent because CSS (touch-action: pan-y)
+        // is applied there to keep vertical scroll responsive while capturing horizontal swipes.
+        <div
+          className={`${styles.mobileContent} shopping-content`}
+          data-testid="shopping-mobile-content"
+          {...swipeHandlers}
+        >
           <div className={styles.mobileTrackWrapper}>
-            <div className={`${styles.mobileTrack} shopping-track`} style={trackStyle}>
+            <div
+              className={`${styles.mobileTrack} shopping-track`}
+              style={trackStyle}
+              data-testid="shopping-track"
+            >
               {lists.map((list, index) => (
-                <div key={list.title} className={styles.mobilePanel}>
+                <div
+                  key={list.title}
+                  className={styles.mobilePanel}
+                  data-testid={`shopping-screen-${index}`}
+                >
                   <div className={styles.mobilePanelInner}>
                     <Checklist
                       title={list.title}

--- a/apps/web/src/pages/ShoppingPage.test.tsx
+++ b/apps/web/src/pages/ShoppingPage.test.tsx
@@ -1,0 +1,212 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Shopping from './Shopping';
+import { createInitialShoppingLists } from './shoppingData';
+
+type SwipePoint = { x: number; y: number };
+
+const setViewportWidth = (width: number) => {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    value: width
+  });
+  window.dispatchEvent(new Event('resize'));
+};
+
+const dispatchSwipe = (
+  element: HTMLElement,
+  start: SwipePoint,
+  moves: SwipePoint[],
+  end: SwipePoint
+) => {
+  fireEvent.touchStart(element, {
+    touches: [{ identifier: 0, clientX: start.x, clientY: start.y }]
+  });
+
+  moves.forEach((point) => {
+    fireEvent.touchMove(element, {
+      touches: [{ identifier: 0, clientX: point.x, clientY: point.y }]
+    });
+  });
+
+  fireEvent.touchEnd(element, {
+    changedTouches: [{ identifier: 0, clientX: end.x, clientY: end.y }]
+  });
+};
+
+describe('Shopping mobile swipe container', () => {
+  beforeEach(() => {
+    setViewportWidth(390);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  const renderShopping = () => render(<Shopping />);
+
+  const getTrack = () => screen.getByTestId('shopping-track');
+
+  it('renders the first screen by default', async () => {
+    renderShopping();
+
+    const firstPagerDot = await screen.findByRole('button', { name: 'Перейти к списку 1' });
+    await waitFor(() => expect(firstPagerDot).toHaveAttribute('aria-pressed', 'true'));
+    await waitFor(() => expect(getTrack().style.transform).toContain('0%'));
+  });
+
+  it('moves to the next screen after a horizontal swipe', async () => {
+    renderShopping();
+
+    const content = screen.getByTestId('shopping-mobile-content');
+    dispatchSwipe(
+      content,
+      { x: 240, y: 240 },
+      [
+        { x: 200, y: 236 },
+        { x: 150, y: 232 }
+      ],
+      { x: 110, y: 228 }
+    );
+
+    await waitFor(() => expect(getTrack().style.transform).toContain('-100%'));
+    const secondPagerDot = await screen.findByRole('button', { name: 'Перейти к списку 2' });
+    await waitFor(() => expect(secondPagerDot).toHaveAttribute('aria-pressed', 'true'));
+  });
+
+  it('ignores a mostly vertical swipe gesture', async () => {
+    renderShopping();
+
+    const content = screen.getByTestId('shopping-mobile-content');
+    dispatchSwipe(
+      content,
+      { x: 180, y: 240 },
+      [
+        { x: 176, y: 280 },
+        { x: 172, y: 320 }
+      ],
+      { x: 170, y: 360 }
+    );
+
+    await waitFor(() => expect(getTrack().style.transform).toContain('0%'));
+    const firstPagerDot = await screen.findByRole('button', { name: 'Перейти к списку 1' });
+    await waitFor(() => expect(firstPagerDot).toHaveAttribute('aria-pressed', 'true'));
+  });
+
+  it('keeps the current screen when toggling checklist items', async () => {
+    renderShopping();
+
+    const initialTransform = getTrack().style.transform;
+    const firstScreen = screen.getByTestId('shopping-screen-0');
+    const firstList = within(firstScreen).getAllByRole('list')[0];
+    const firstItem = within(firstList).getAllByRole('button')[0];
+
+    fireEvent.click(firstItem);
+
+    await waitFor(() => expect(getTrack().style.transform).toBe(initialTransform));
+  });
+
+  it('stops at the bounds when swiping beyond available screens', async () => {
+    renderShopping();
+
+    const content = screen.getByTestId('shopping-mobile-content');
+
+    // Swipe right on the first screen – should stay at index 0.
+    dispatchSwipe(
+      content,
+      { x: 100, y: 220 },
+      [
+        { x: 150, y: 224 },
+        { x: 200, y: 228 }
+      ],
+      { x: 250, y: 232 }
+    );
+
+    await waitFor(() => expect(getTrack().style.transform).toContain('0%'));
+
+    // Swipe left twice to reach the last screen.
+    dispatchSwipe(
+      content,
+      { x: 260, y: 220 },
+      [
+        { x: 210, y: 216 },
+        { x: 160, y: 212 }
+      ],
+      { x: 120, y: 208 }
+    );
+
+    await waitFor(() => expect(getTrack().style.transform).toContain('-100%'));
+
+    dispatchSwipe(
+      content,
+      { x: 260, y: 220 },
+      [
+        { x: 210, y: 216 },
+        { x: 160, y: 212 }
+      ],
+      { x: 100, y: 208 }
+    );
+
+    await waitFor(() => expect(getTrack().style.transform).toContain('-200%'));
+
+    // One more left swipe should keep us at the last screen.
+    dispatchSwipe(
+      content,
+      { x: 250, y: 220 },
+      [
+        { x: 200, y: 216 },
+        { x: 150, y: 212 }
+      ],
+      { x: 90, y: 208 }
+    );
+
+    await waitFor(() => expect(getTrack().style.transform).toContain('-200%'));
+
+    // Swiping right once should return to the middle screen.
+    dispatchSwipe(
+      content,
+      { x: 100, y: 220 },
+      [
+        { x: 150, y: 224 },
+        { x: 200, y: 228 }
+      ],
+      { x: 240, y: 232 }
+    );
+
+    await waitFor(() => expect(getTrack().style.transform).toContain('-100%'));
+  });
+
+  it('keeps pager position when interacting with inputs inside other lists', async () => {
+    renderShopping();
+
+    const lists = createInitialShoppingLists();
+    const content = screen.getByTestId('shopping-mobile-content');
+
+    dispatchSwipe(
+      content,
+      { x: 240, y: 240 },
+      [
+        { x: 200, y: 236 },
+        { x: 150, y: 232 }
+      ],
+      { x: 100, y: 228 }
+    );
+
+    const secondScreen = screen.getByTestId('shopping-screen-1');
+    const addButton = within(secondScreen).getByRole('button', { name: '+ добавить' });
+
+    fireEvent.click(addButton);
+
+    const categorySelect = await screen.findByLabelText('Категория');
+    fireEvent.change(categorySelect, { target: { value: lists[1]?.title ?? '' } });
+    const titleInput = await screen.findByLabelText('Название');
+    fireEvent.change(titleInput, { target: { value: 'Мыло' } });
+    fireEvent.click(await screen.findByRole('button', { name: 'Добавить' }));
+
+    await waitFor(() => expect(getTrack().style.transform).toContain('-100%'));
+    const secondPagerDot = await screen.findByRole('button', { name: 'Перейти к списку 2' });
+    await waitFor(() => expect(secondPagerDot).toHaveAttribute('aria-pressed', 'true'));
+  });
+});

--- a/apps/web/src/pages/shopping/ShoppingLayout.module.css
+++ b/apps/web/src/pages/shopping/ShoppingLayout.module.css
@@ -38,6 +38,8 @@
   width: 100%;
   padding-bottom: 0;
   padding-bottom: env(safe-area-inset-bottom);
+  /* Allow vertical scroll gestures to pass through while we intercept horizontal swipes. */
+  touch-action: pan-y;
 }
 
 .mobileTrackWrapper {


### PR DESCRIPTION
## Summary
- reattach swipe handlers to the Shopping mobile surface and guard swipe bounds while documenting the layout
- enable mouse tracking in the local react-swipeable shim and apply touch-action so horizontal gestures register reliably
- add gesture-focused Shopping page tests and README notes covering swipe options and test execution

## Testing
- npm --workspace apps/web run test

------
https://chatgpt.com/codex/tasks/task_e_68dfc3c89f5083249d2486623cdf14c9