### PR TITLE
feat(web): add calendar views with mock data

### DIFF
--- a/apps/web/src/pages/Calendar.css
+++ b/apps/web/src/pages/Calendar.css
@@ -1,0 +1,243 @@
+.calendar-page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px 16px 24px;
+  min-height: 100%;
+}
+
+.calendar-selected-date {
+  font-size: clamp(16px, 4vw, 18px);
+  font-weight: 500;
+  text-align: center;
+  text-transform: capitalize;
+  color: var(--app-color-text-secondary);
+}
+
+.calendar-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.calendar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.calendar-header-title {
+  flex: 1;
+  text-align: center;
+  font-size: clamp(18px, 4.5vw, 22px);
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.calendar-arrow {
+  border: none;
+  background: var(--app-color-surface-subtle);
+  color: var(--app-color-text-primary);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  font-size: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.calendar-arrow:focus-visible,
+.calendar-bottom-button:focus-visible,
+.calendar-month-day:focus-visible,
+.calendar-week-day:focus-visible,
+.calendar-year-month:focus-visible {
+  outline: 2px solid var(--app-color-primary);
+  outline-offset: 2px;
+}
+
+.calendar-weekday-row {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 8px;
+  font-size: clamp(12px, 3vw, 14px);
+  color: var(--app-color-text-muted);
+  text-transform: uppercase;
+}
+
+.calendar-weekday-label {
+  text-align: center;
+}
+
+.calendar-month-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.calendar-month-day {
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 12px 0;
+  background: var(--app-color-surface-subtle);
+  color: var(--app-color-text-primary);
+  font-size: clamp(14px, 3.5vw, 16px);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.calendar-day-outside {
+  color: var(--app-color-text-muted);
+  background: transparent;
+}
+
+.calendar-day-selected {
+  border-color: var(--app-color-primary);
+}
+
+.calendar-day-today {
+  background: rgba(34, 197, 94, 0.18);
+  border-color: var(--app-color-primary);
+}
+
+.calendar-week-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.calendar-week-day {
+  position: relative;
+  text-align: left;
+  border: 1px solid transparent;
+  border-radius: 16px;
+  padding: 12px;
+  background: var(--app-color-surface-subtle);
+  color: var(--app-color-text-primary);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  cursor: pointer;
+  min-height: 120px;
+}
+
+.calendar-week-day.calendar-day-selected {
+  border-color: var(--app-color-primary);
+}
+
+.calendar-week-day.calendar-day-today {
+  background: rgba(34, 197, 94, 0.18);
+  border-color: var(--app-color-primary);
+}
+
+.calendar-week-sunday {
+  grid-column: 1 / -1;
+}
+
+.calendar-week-day-header {
+  display: flex;
+  justify-content: flex-end;
+  align-items: baseline;
+  gap: 6px;
+  font-weight: 600;
+  font-size: clamp(13px, 3.2vw, 15px);
+  text-transform: uppercase;
+}
+
+.calendar-week-day-number {
+  font-size: clamp(18px, 5vw, 22px);
+}
+
+.calendar-week-event-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: clamp(12px, 3.2vw, 14px);
+  color: var(--app-color-text-secondary);
+}
+
+.calendar-week-event-item {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.calendar-week-event-more {
+  color: var(--app-color-primary);
+  font-weight: 600;
+}
+
+.calendar-week-event-empty {
+  color: var(--app-color-text-muted);
+}
+
+.calendar-year-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.calendar-year-month {
+  border-radius: 14px;
+  border: 1px solid transparent;
+  padding: 14px 12px;
+  text-transform: capitalize;
+  font-weight: 600;
+  font-size: clamp(14px, 3.6vw, 16px);
+  background: var(--app-color-surface-subtle);
+  cursor: pointer;
+}
+
+.calendar-bottom-nav {
+  display: flex;
+  gap: 8px;
+  margin-top: auto;
+  margin-bottom: 8px;
+}
+
+.calendar-bottom-button {
+  flex: 1;
+  border-radius: 20px;
+  border: 1px solid var(--app-color-divider);
+  background: var(--app-color-surface);
+  padding: 10px 12px;
+  font-weight: 600;
+  font-size: clamp(14px, 3.5vw, 16px);
+  cursor: pointer;
+  color: var(--app-color-text-secondary);
+}
+
+.calendar-bottom-button-active {
+  background: var(--app-color-primary);
+  border-color: var(--app-color-primary);
+  color: var(--app-color-primary-contrast);
+}
+
+@media (min-width: 600px) {
+  .calendar-year-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 768px) {
+  .calendar-page {
+    padding: 24px 24px 28px;
+  }
+
+  .calendar-week-grid {
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+
+  .calendar-week-sunday {
+    grid-column: auto;
+  }
+
+  .calendar-year-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}

--- a/apps/web/src/pages/Calendar.test.tsx
+++ b/apps/web/src/pages/Calendar.test.tsx
@@ -1,0 +1,156 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type CalendarEvent = {
+  id: string;
+  dateISO: string;
+  title: string;
+};
+
+const eventsByMonth = vi.hoisted((): Record<string, CalendarEvent[]> => ({
+  '2024-4': [
+    { id: 'm1', dateISO: '2024-05-13T09:00:00.000Z', title: 'Понедельник' },
+    { id: 'm2', dateISO: '2024-05-14T09:30:00.000Z', title: 'Вторник' },
+    { id: 'm3', dateISO: '2024-05-15T08:00:00.000Z', title: 'Событие 1' },
+    { id: 'm4', dateISO: '2024-05-15T10:00:00.000Z', title: 'Событие 2' },
+    { id: 'm5', dateISO: '2024-05-15T12:00:00.000Z', title: 'Событие 3' },
+    { id: 'm6', dateISO: '2024-05-15T14:00:00.000Z', title: 'Событие 4' },
+    { id: 'm7', dateISO: '2024-05-19T09:00:00.000Z', title: 'Воскресенье' },
+    { id: 'm8', dateISO: '2024-05-21T09:00:00.000Z', title: 'Событие 5' },
+    { id: 'm9', dateISO: '2024-05-22T09:00:00.000Z', title: 'Событие 6' },
+    { id: 'm10', dateISO: '2024-05-25T09:00:00.000Z', title: 'Событие 7' }
+  ],
+  '2024-5': [
+    { id: 'j1', dateISO: '2024-06-10T09:00:00.000Z', title: 'Июнь' }
+  ]
+}));
+
+vi.mock('./calendar/mockEvents', () => ({
+  generateMonthlyMockEvents: vi.fn((year: number, month: number) => {
+    const map = eventsByMonth as Record<string, CalendarEvent[]>;
+    return map[`${year}-${month}`] ?? [];
+  })
+}));
+
+import Calendar from './Calendar';
+
+const setViewportWidth = (width: number) => {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width
+  });
+  window.dispatchEvent(new Event('resize'));
+};
+
+const resetViewportWidth = () => setViewportWidth(1024);
+
+describe('Calendar page', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-05-15T09:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    resetViewportWidth();
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('renders the month grid starting on Monday with leading and trailing days', () => {
+    render(<Calendar />);
+
+    const monthGrid = screen.getByTestId('calendar-month-grid');
+    const dayButtons = within(monthGrid).getAllByRole('button');
+
+    const firstRowNumbers = dayButtons.slice(0, 7).map((button) => button.textContent?.trim());
+    expect(firstRowNumbers).toEqual(['29', '30', '1', '2', '3', '4', '5']);
+
+    const lastRowNumbers = dayButtons
+      .slice(-7)
+      .map((button) => button.textContent?.trim());
+    expect(lastRowNumbers).toEqual(['27', '28', '29', '30', '31', '1', '2']);
+  });
+
+  it('highlights today and updates the selected day display when another day is chosen', () => {
+    render(<Calendar />);
+
+    const todayButton = screen.getByTestId('calendar-day-2024-05-15');
+    expect(todayButton.className).toContain('calendar-day-today');
+    expect(todayButton.className).toContain('calendar-day-selected');
+
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent('15 мая 2024');
+
+    const newDayButton = screen.getByTestId('calendar-day-2024-05-21');
+    fireEvent.click(newDayButton);
+
+    expect(newDayButton.className).toContain('calendar-day-selected');
+    expect(status).toHaveTextContent('21 мая 2024');
+  });
+
+  it('switches months and years using the header arrows and opens a month from the year view', () => {
+    render(<Calendar />);
+
+    const nextMonthButton = screen.getByRole('button', { name: 'Следующий месяц' });
+    fireEvent.click(nextMonthButton);
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('июнь 2024');
+
+    const yearTab = screen.getByRole('button', { name: 'Перейти к году' });
+    fireEvent.click(yearTab);
+
+    const nextYearButton = screen.getByRole('button', { name: 'Следующий год' });
+    fireEvent.click(nextYearButton);
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('2025');
+
+    const mayButton = screen.getByRole('button', { name: 'Открыть май 2025' });
+    fireEvent.click(mayButton);
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('май 2025');
+  });
+
+  it('changes views using the bottom navigation buttons', () => {
+    render(<Calendar />);
+
+    const weekButton = screen.getByRole('button', { name: 'Перейти к неделе' });
+    const yearButton = screen.getByRole('button', { name: 'Перейти к году' });
+    const monthButton = screen.getByRole('button', { name: 'Перейти к месяцу' });
+
+    fireEvent.click(weekButton);
+    expect(weekButton).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(yearButton);
+    expect(yearButton).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(monthButton);
+    expect(monthButton).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('lays out the week view as 2x3 tiles with a wide Sunday tile on mobile width', () => {
+    setViewportWidth(390);
+    render(<Calendar />);
+
+    const weekButton = screen.getByRole('button', { name: 'Перейти к неделе' });
+    fireEvent.click(weekButton);
+
+    const weekGrid = screen.getByTestId('calendar-week-grid');
+    const dayTiles = within(weekGrid).getAllByRole('button');
+    expect(dayTiles).toHaveLength(7);
+
+    const sundayTile = screen.getByTestId('week-day-2024-05-19');
+    expect(sundayTile.className).toContain('calendar-week-sunday');
+  });
+
+  it('renders at most three events per day in the week view and shows a +N indicator', () => {
+    setViewportWidth(390);
+    render(<Calendar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Перейти к неделе' }));
+
+    const wednesdayTile = screen.getByTestId('week-day-2024-05-15');
+    const eventsList = within(wednesdayTile).getByRole('list');
+    const eventItems = within(eventsList).getAllByRole('listitem');
+    const visibleTitles = eventItems.map((item) => item.textContent);
+
+    expect(visibleTitles).toEqual(['Событие 1', 'Событие 2', 'Событие 3', '+1']);
+  });
+});

--- a/apps/web/src/pages/Calendar.tsx
+++ b/apps/web/src/pages/Calendar.tsx
@@ -1,7 +1,365 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { CalendarEvent, generateMonthlyMockEvents } from './calendar/mockEvents';
+import './Calendar.css';
+
+type CalendarView = 'week' | 'month' | 'year';
+
+const WEEKDAY_LABELS = ['ПН', 'ВТ', 'СР', 'ЧТ', 'ПТ', 'СБ', 'ВС'];
+const MONTH_LABELS = [
+  'Январь',
+  'Февраль',
+  'Март',
+  'Апрель',
+  'Май',
+  'Июнь',
+  'Июль',
+  'Август',
+  'Сентябрь',
+  'Октябрь',
+  'Ноябрь',
+  'Декабрь'
+];
+
+const formatLongDate = (date: Date) => {
+  const formatted = new Intl.DateTimeFormat('ru-RU', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric'
+  }).format(date);
+
+  return formatted.replace(' г.', '');
+};
+
+const formatMonthHeading = (date: Date) => {
+  const formatted = new Intl.DateTimeFormat('ru-RU', {
+    month: 'long',
+    year: 'numeric'
+  }).format(date);
+
+  return formatted.replace(' г.', '');
+};
+
+const getStartOfDay = (source: Date) =>
+  new Date(source.getFullYear(), source.getMonth(), source.getDate());
+
+const addDays = (source: Date, amount: number) => {
+  const result = new Date(source);
+  result.setDate(result.getDate() + amount);
+  return getStartOfDay(result);
+};
+
+const addMonths = (source: Date, amount: number) =>
+  new Date(source.getFullYear(), source.getMonth() + amount, 1);
+
+const getMonthGrid = (monthDate: Date) => {
+  const firstDayOfMonth = new Date(
+    monthDate.getFullYear(),
+    monthDate.getMonth(),
+    1
+  );
+  const leadingDays = (firstDayOfMonth.getDay() + 6) % 7;
+  const daysInMonth = new Date(
+    monthDate.getFullYear(),
+    monthDate.getMonth() + 1,
+    0
+  ).getDate();
+  const totalCells = Math.ceil((leadingDays + daysInMonth) / 7) * 7;
+  const startDate = addDays(firstDayOfMonth, -leadingDays);
+
+  return Array.from({ length: totalCells }, (_, index) =>
+    addDays(startDate, index)
+  );
+};
+
+const getStartOfWeek = (date: Date) => {
+  const start = getStartOfDay(date);
+  const offset = (start.getDay() + 6) % 7;
+  return addDays(start, -offset);
+};
+
+const toDateKey = (date: Date) =>
+  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(
+    date.getDate()
+  ).padStart(2, '0')}`;
+
+const useMonthEvents = () => {
+  const cacheRef = useRef(new Map<string, CalendarEvent[]>());
+
+  const ensureMonthEvents = useCallback((year: number, month: number) => {
+    const key = `${year}-${month}`;
+    const cache = cacheRef.current;
+
+    if (!cache.has(key)) {
+      cache.set(key, generateMonthlyMockEvents(year, month));
+    }
+
+    return cache.get(key) ?? [];
+  }, []);
+
+  const getEventsForDate = useCallback(
+    (date: Date) => {
+      const events = ensureMonthEvents(date.getFullYear(), date.getMonth());
+      const key = toDateKey(date);
+      return events.filter((event) => event.dateISO.startsWith(key));
+    },
+    [ensureMonthEvents]
+  );
+
+  return { getEventsForDate };
+};
+
 const Calendar = () => {
+  const today = useMemo(() => getStartOfDay(new Date()), []);
+  const [view, setView] = useState<CalendarView>('month');
+  const [selectedDate, setSelectedDate] = useState<Date>(today);
+  const [monthCursor, setMonthCursor] = useState<Date>(
+    new Date(today.getFullYear(), today.getMonth(), 1)
+  );
+  const [yearCursor, setYearCursor] = useState<number>(today.getFullYear());
+
+  const { getEventsForDate } = useMonthEvents();
+
+  const handleSelectDate = useCallback((date: Date) => {
+    const normalized = getStartOfDay(date);
+    setSelectedDate(normalized);
+    setMonthCursor(new Date(normalized.getFullYear(), normalized.getMonth(), 1));
+    setYearCursor(normalized.getFullYear());
+  }, []);
+
+  const handleChangeMonth = (amount: number) => {
+    setMonthCursor((current) => {
+      const next = addMonths(current, amount);
+      setYearCursor(next.getFullYear());
+      return next;
+    });
+  };
+
+  const handleChangeYear = (amount: number) => {
+    setYearCursor((current) => current + amount);
+  };
+
+  const monthDays = useMemo(() => getMonthGrid(monthCursor), [monthCursor]);
+  const weekStart = useMemo(() => getStartOfWeek(selectedDate), [selectedDate]);
+  const weekDays = useMemo(
+    () => Array.from({ length: 7 }, (_, index) => addDays(weekStart, index)),
+    [weekStart]
+  );
+
+  const isToday = useCallback(
+    (date: Date) => date.getTime() === today.getTime(),
+    [today]
+  );
+
+  const isSelected = useCallback(
+    (date: Date) => date.getTime() === selectedDate.getTime(),
+    [selectedDate]
+  );
+
+  const renderMonthView = () => (
+    <>
+      <div className="calendar-header">
+        <button
+          type="button"
+          aria-label="Предыдущий месяц"
+          className="calendar-arrow"
+          onClick={() => handleChangeMonth(-1)}
+        >
+          ‹
+        </button>
+        <div className="calendar-header-title" role="heading" aria-level={2}>
+          {formatMonthHeading(monthCursor)}
+        </div>
+        <button
+          type="button"
+          aria-label="Следующий месяц"
+          className="calendar-arrow"
+          onClick={() => handleChangeMonth(1)}
+        >
+          ›
+        </button>
+      </div>
+      <div className="calendar-weekday-row" aria-hidden="true">
+        {WEEKDAY_LABELS.map((label) => (
+          <span key={label} className="calendar-weekday-label">
+            {label}
+          </span>
+        ))}
+      </div>
+      <div className="calendar-month-grid" data-testid="calendar-month-grid">
+        {monthDays.map((day) => {
+          const outsideCurrentMonth =
+            day.getMonth() !== monthCursor.getMonth();
+          const selected = isSelected(day);
+          const todayMatch = isToday(day);
+
+          return (
+            <button
+              key={toDateKey(day)}
+              type="button"
+              data-testid={`calendar-day-${toDateKey(day)}`}
+              className={`calendar-month-day${
+                outsideCurrentMonth ? ' calendar-day-outside' : ''
+              }${selected ? ' calendar-day-selected' : ''}${
+                todayMatch ? ' calendar-day-today' : ''
+              }`}
+              aria-label={`Выбрать ${new Intl.DateTimeFormat('ru-RU', {
+                weekday: 'long',
+                day: 'numeric',
+                month: 'long',
+                year: 'numeric'
+              }).format(day)}`}
+              onClick={() => handleSelectDate(day)}
+            >
+              <span>{day.getDate()}</span>
+            </button>
+          );
+        })}
+      </div>
+    </>
+  );
+
+  const renderWeekView = () => (
+    <div className="calendar-week-grid" data-testid="calendar-week-grid">
+      {weekDays.map((day, index) => {
+        const events = getEventsForDate(day);
+        const maxVisible = 3;
+        const visibleEvents = events.slice(0, maxVisible);
+        const remaining = events.length - visibleEvents.length;
+        const selected = isSelected(day);
+        const todayMatch = isToday(day);
+
+        return (
+          <button
+            key={toDateKey(day)}
+            type="button"
+            data-testid={`week-day-${toDateKey(day)}`}
+            className={`calendar-week-day${selected ? ' calendar-day-selected' : ''}${
+              todayMatch ? ' calendar-day-today' : ''
+            }${index === 6 ? ' calendar-week-sunday' : ''}`}
+            aria-label={`Выбрать ${new Intl.DateTimeFormat('ru-RU', {
+              weekday: 'long',
+              day: 'numeric',
+              month: 'long',
+              year: 'numeric'
+            }).format(day)}`}
+            onClick={() => handleSelectDate(day)}
+          >
+            <div className="calendar-week-day-header">
+              <span className="calendar-week-day-label">{WEEKDAY_LABELS[index]}</span>
+              <span className="calendar-week-day-number">{day.getDate()}</span>
+            </div>
+            <ul className="calendar-week-event-list">
+              {visibleEvents.map((event) => (
+                <li key={event.id} className="calendar-week-event-item">
+                  {event.title}
+                </li>
+              ))}
+              {remaining > 0 ? (
+                <li className="calendar-week-event-more">+{remaining}</li>
+              ) : null}
+              {visibleEvents.length === 0 && remaining <= 0 ? (
+                <li className="calendar-week-event-empty">Нет событий</li>
+              ) : null}
+            </ul>
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  const renderYearView = () => (
+    <>
+      <div className="calendar-header">
+        <button
+          type="button"
+          aria-label="Предыдущий год"
+          className="calendar-arrow"
+          onClick={() => handleChangeYear(-1)}
+        >
+          ‹
+        </button>
+        <div className="calendar-header-title" role="heading" aria-level={2}>
+          {yearCursor}
+        </div>
+        <button
+          type="button"
+          aria-label="Следующий год"
+          className="calendar-arrow"
+          onClick={() => handleChangeYear(1)}
+        >
+          ›
+        </button>
+      </div>
+      <div className="calendar-year-grid">
+        {MONTH_LABELS.map((label, index) => (
+          <button
+            key={label}
+            type="button"
+            className="calendar-year-month"
+            aria-label={`Открыть ${label.toLowerCase()} ${yearCursor}`}
+            onClick={() => {
+              const nextMonth = new Date(yearCursor, index, 1);
+              handleSelectDate(nextMonth);
+              setView('month');
+            }}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+
   return (
-    <section className="centered-page">
+    <section className="calendar-page">
       <h1 className="page-title">Календарь</h1>
+      <div className="calendar-selected-date" role="status" aria-live="polite">
+        {formatLongDate(selectedDate)}
+      </div>
+      <div className="calendar-content">
+        {view === 'month' && renderMonthView()}
+        {view === 'week' && renderWeekView()}
+        {view === 'year' && renderYearView()}
+      </div>
+      <nav
+        className="calendar-bottom-nav"
+        aria-label="Переключение режимов календаря"
+        data-testid="calendar-bottom-nav"
+      >
+        <button
+          type="button"
+          className={`calendar-bottom-button${
+            view === 'week' ? ' calendar-bottom-button-active' : ''
+          }`}
+          aria-pressed={view === 'week'}
+          aria-label="Перейти к неделе"
+          onClick={() => setView('week')}
+        >
+          Неделя
+        </button>
+        <button
+          type="button"
+          className={`calendar-bottom-button${
+            view === 'month' ? ' calendar-bottom-button-active' : ''
+          }`}
+          aria-pressed={view === 'month'}
+          aria-label="Перейти к месяцу"
+          onClick={() => setView('month')}
+        >
+          Месяц
+        </button>
+        <button
+          type="button"
+          className={`calendar-bottom-button${
+            view === 'year' ? ' calendar-bottom-button-active' : ''
+          }`}
+          aria-pressed={view === 'year'}
+          aria-label="Перейти к году"
+          onClick={() => setView('year')}
+        >
+          Год
+        </button>
+      </nav>
     </section>
   );
 };

--- a/apps/web/src/pages/calendar/mockEvents.ts
+++ b/apps/web/src/pages/calendar/mockEvents.ts
@@ -1,0 +1,92 @@
+export type CalendarEvent = {
+  id: string;
+  dateISO: string;
+  title: string;
+};
+
+type RandomGenerator = () => number;
+
+const createRandom = (seed: number): RandomGenerator => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), 1 | t);
+    t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const TITLE_PARTS = [
+  'Встреча',
+  'Созвон',
+  'Семья',
+  'Друзья',
+  'Праздник',
+  'Покупки',
+  'Спорт',
+  'Врач',
+  'Поручение',
+  'Дети'
+];
+
+const ensureOverflowDay = (events: CalendarEvent[], year: number, month: number) => {
+  if (events.length < 4) {
+    return events;
+  }
+
+  const counts = new Map<string, number>();
+
+  for (const event of events) {
+    const dayKey = event.dateISO.slice(0, 10);
+    counts.set(dayKey, (counts.get(dayKey) ?? 0) + 1);
+  }
+
+  const hasOverflow = Array.from(counts.values()).some((count) => count > 3);
+
+  if (hasOverflow) {
+    return events;
+  }
+
+  const firstDayKey = `${year}-${String(month + 1).padStart(2, '0')}-${String(1).padStart(
+    2,
+    '0'
+  )}`;
+  const overflowDateISO = new Date(Date.UTC(year, month, 1, 9, 0, 0)).toISOString();
+
+  for (let index = 0; index < Math.min(4, events.length); index += 1) {
+    events[index] = {
+      ...events[index],
+      dateISO: overflowDateISO,
+      id: `${events[index].id}-d${index}`
+    };
+  }
+
+  counts.set(firstDayKey, Math.min(4, events.length));
+  return events;
+};
+
+export const generateMonthlyMockEvents = (year: number, month: number): CalendarEvent[] => {
+  const random = createRandom(year * 100 + month + 1);
+  const eventsCount = 10 + Math.floor(random() * 11);
+  const events: CalendarEvent[] = [];
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  for (let index = 0; index < eventsCount; index += 1) {
+    const day = 1 + Math.floor(random() * daysInMonth);
+    const date = new Date(Date.UTC(year, month, day, 9, 0, 0));
+    const titleIndex = Math.floor(random() * TITLE_PARTS.length);
+    const titleSuffix = Math.floor(random() * 9) + 1;
+    events.push({
+      id: `${year}-${month}-${index}`,
+      dateISO: date.toISOString(),
+      title: `${TITLE_PARTS[titleIndex]} #${titleSuffix}`
+    });
+  }
+
+  events.sort((a, b) => a.dateISO.localeCompare(b.dateISO));
+
+  ensureOverflowDay(events, year, month);
+
+  return events;
+};


### PR DESCRIPTION
## Summary
- implement the calendar page with week, month, and year screens plus shared navigation
- add deterministic mock event generation and responsive styling for all calendar views
- cover calendar interactions and layout requirements with unit tests

## Testing
- npm --workspace apps/web test src/pages/Calendar.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e0a595d9ec8324a20851384d089620