### PR TITLE
Adjust calendar week header formatting and highlight

### DIFF
--- a/apps/web/src/pages/Calendar.css
+++ b/apps/web/src/pages/Calendar.css
@@ -6,12 +6,26 @@
   min-height: 100%;
 }
 
-.calendar-selected-date {
-  font-size: clamp(16px, 4vw, 18px);
-  font-weight: 500;
+.calendar-header-today {
+  font-size: clamp(18px, 4.5vw, 22px);
   text-align: center;
-  text-transform: capitalize;
-  color: var(--app-color-text-secondary);
+  color: var(--app-color-text-primary);
+}
+
+.calendar-header-today strong {
+  font-weight: 700;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .calendar-content {
@@ -98,8 +112,9 @@
 }
 
 .calendar-day-today {
-  background: rgba(34, 197, 94, 0.18);
+  background: rgba(34, 197, 94, 0.12);
   border-color: var(--app-color-primary);
+  border-width: 2px;
 }
 
 .calendar-week-grid {
@@ -128,8 +143,9 @@
 }
 
 .calendar-week-day.calendar-day-today {
-  background: rgba(34, 197, 94, 0.18);
+  background: rgba(34, 197, 94, 0.12);
   border-color: var(--app-color-primary);
+  border-width: 2px;
 }
 
 .calendar-week-sunday {
@@ -137,17 +153,12 @@
 }
 
 .calendar-week-day-header {
-  display: flex;
-  justify-content: flex-end;
-  align-items: baseline;
-  gap: 6px;
   font-weight: 600;
-  font-size: clamp(13px, 3.2vw, 15px);
-  text-transform: uppercase;
-}
-
-.calendar-week-day-number {
-  font-size: clamp(18px, 5vw, 22px);
+  font-size: clamp(14px, 3.8vw, 16px);
+  line-height: 1.2;
+  text-align: left;
+  text-transform: none;
+  word-break: break-word;
 }
 
 .calendar-week-event-list {
@@ -170,10 +181,6 @@
 .calendar-week-event-more {
   color: var(--app-color-primary);
   font-weight: 600;
-}
-
-.calendar-week-event-empty {
-  color: var(--app-color-text-muted);
 }
 
 .calendar-year-grid {

--- a/apps/web/src/pages/Calendar.tsx
+++ b/apps/web/src/pages/Calendar.tsx
@@ -155,6 +155,24 @@ const Calendar = () => {
     [selectedDate]
   );
 
+  const weekdayLongFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat('ru-RU', {
+        weekday: 'long'
+      }),
+    []
+  );
+
+  const formatWeekdayLabel = useCallback(
+    (date: Date) => {
+      const weekday = weekdayLongFormatter.format(date);
+      const capitalizedWeekday =
+        weekday.charAt(0).toUpperCase() + weekday.slice(1);
+      return `${capitalizedWeekday}, ${date.getDate()}`;
+    },
+    [weekdayLongFormatter]
+  );
+
   const renderMonthView = () => (
     <>
       <div className="calendar-header">
@@ -197,6 +215,7 @@ const Calendar = () => {
               key={toDateKey(day)}
               type="button"
               data-testid={`calendar-day-${toDateKey(day)}`}
+              data-today={todayMatch ? 'true' : undefined}
               className={`calendar-month-day${
                 outsideCurrentMonth ? ' calendar-day-outside' : ''
               }${selected ? ' calendar-day-selected' : ''}${
@@ -233,6 +252,7 @@ const Calendar = () => {
             key={toDateKey(day)}
             type="button"
             data-testid={`week-day-${toDateKey(day)}`}
+            data-today={todayMatch ? 'true' : undefined}
             className={`calendar-week-day${selected ? ' calendar-day-selected' : ''}${
               todayMatch ? ' calendar-day-today' : ''
             }${index === 6 ? ' calendar-week-sunday' : ''}`}
@@ -245,8 +265,7 @@ const Calendar = () => {
             onClick={() => handleSelectDate(day)}
           >
             <div className="calendar-week-day-header">
-              <span className="calendar-week-day-label">{WEEKDAY_LABELS[index]}</span>
-              <span className="calendar-week-day-number">{day.getDate()}</span>
+              {formatWeekdayLabel(day)}
             </div>
             <ul className="calendar-week-event-list">
               {visibleEvents.map((event) => (
@@ -256,9 +275,6 @@ const Calendar = () => {
               ))}
               {remaining > 0 ? (
                 <li className="calendar-week-event-more">+{remaining}</li>
-              ) : null}
-              {visibleEvents.length === 0 && remaining <= 0 ? (
-                <li className="calendar-week-event-empty">Нет событий</li>
               ) : null}
             </ul>
           </button>
@@ -312,10 +328,12 @@ const Calendar = () => {
 
   return (
     <section className="calendar-page">
-      <h1 className="page-title">Календарь</h1>
-      <div className="calendar-selected-date" role="status" aria-live="polite">
-        {formatLongDate(selectedDate)}
+      <div className="calendar-header-today" data-testid="calendar-header-today">
+        <strong>{formatLongDate(today)}</strong>
       </div>
+      <span className="visually-hidden" role="status" aria-live="polite">
+        {formatLongDate(selectedDate)}
+      </span>
       <div className="calendar-content">
         {view === 'month' && renderMonthView()}
         {view === 'week' && renderWeekView()}


### PR DESCRIPTION
## Summary
- replace the calendar page heading with a bold ru-RU formatted date and keep an accessible status region
- render week tiles with full weekday names, drop empty placeholders, and add today markers
- tune styles for the new headers and today highlight plus update the accompanying tests

## Testing
- npm --workspace apps/web test -- src/pages/Calendar.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e0b23fc0c88324b8cca3eaaf5326e8