### PR TITLE
Rework week calendar layout and event bullets

### DIFF
--- a/apps/web/src/pages/Calendar.css
+++ b/apps/web/src/pages/Calendar.css
@@ -118,8 +118,15 @@
 }
 
 .calendar-week-grid {
+  --calendar-week-caption-size: clamp(13px, 3.6vw, 16px);
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-areas:
+    'monday thursday'
+    'tuesday friday'
+    'wednesday saturday'
+    'sunday sunday';
+  grid-auto-rows: 1fr;
   gap: 12px;
 }
 
@@ -148,17 +155,44 @@
   border-width: 2px;
 }
 
-.calendar-week-sunday {
-  grid-column: 1 / -1;
+.calendar-week-day--monday {
+  grid-area: monday;
 }
 
-.calendar-week-day-header {
+.calendar-week-day--tuesday {
+  grid-area: tuesday;
+}
+
+.calendar-week-day--wednesday {
+  grid-area: wednesday;
+}
+
+.calendar-week-day--thursday {
+  grid-area: thursday;
+}
+
+.calendar-week-day--friday {
+  grid-area: friday;
+}
+
+.calendar-week-day--saturday {
+  grid-area: saturday;
+}
+
+.calendar-week-day--sunday,
+.calendar-week-sunday {
+  grid-area: sunday;
+}
+
+.calendar-week-day-caption {
   font-weight: 600;
-  font-size: clamp(14px, 3.8vw, 16px);
+  font-size: var(--calendar-week-caption-size);
   line-height: 1.2;
   text-align: left;
   text-transform: none;
-  word-break: break-word;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .calendar-week-event-list {
@@ -173,6 +207,20 @@
 }
 
 .calendar-week-event-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 1.2em;
+}
+
+.calendar-week-event-bullet {
+  font-weight: 700;
+  color: var(--app-color-text-primary);
+  flex: 0 0 auto;
+  line-height: 1;
+}
+
+.calendar-week-event-text {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/apps/web/src/pages/Calendar.test.tsx
+++ b/apps/web/src/pages/Calendar.test.tsx
@@ -135,7 +135,7 @@ describe('Calendar page', () => {
     expect(monthButton).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('lays out the week view as 2x3 tiles with full weekday labels and wide Sunday on mobile width', () => {
+  it('lays out the week view with stacked columns and a wide Sunday tile on mobile width', () => {
     setViewportWidth(390);
     render(<Calendar />);
 
@@ -152,6 +152,27 @@ describe('Calendar page', () => {
     const mondayTile = screen.getByTestId('week-day-2024-05-13');
     expect(mondayTile).toHaveTextContent('Понедельник, 13');
     expect(sundayTile).toHaveTextContent('Воскресенье, 19');
+
+    const expectedClassMap: Record<string, string> = {
+      'week-day-2024-05-13': 'calendar-week-day--monday',
+      'week-day-2024-05-14': 'calendar-week-day--tuesday',
+      'week-day-2024-05-15': 'calendar-week-day--wednesday',
+      'week-day-2024-05-16': 'calendar-week-day--thursday',
+      'week-day-2024-05-17': 'calendar-week-day--friday',
+      'week-day-2024-05-18': 'calendar-week-day--saturday',
+      'week-day-2024-05-19': 'calendar-week-day--sunday'
+    };
+
+    Object.entries(expectedClassMap).forEach(([testId, className]) => {
+      expect(screen.getByTestId(testId).className).toContain(className);
+    });
+
+    const captions = weekGrid.querySelectorAll('[data-caption-size="shared"]');
+    expect(captions).toHaveLength(7);
+    captions.forEach((caption) => {
+      expect(caption.getAttribute('data-caption-size')).toBe('shared');
+      expect(caption.getAttribute('data-nowrap')).toBe('true');
+    });
   });
 
   it('renders at most three events per day in the week view and shows a +N indicator', () => {
@@ -165,7 +186,12 @@ describe('Calendar page', () => {
     const eventItems = within(eventsList).getAllByRole('listitem');
     const visibleTitles = eventItems.map((item) => item.textContent);
 
-    expect(visibleTitles).toEqual(['Событие 1', 'Событие 2', 'Событие 3', '+1']);
+    expect(visibleTitles).toEqual(['•Событие 1', '•Событие 2', '•Событие 3', '+1']);
+
+    const bulletItems = eventItems.slice(0, 3);
+    bulletItems.forEach((item) => {
+      expect(item.textContent?.startsWith('•')).toBe(true);
+    });
   });
 
   it('hides empty-state placeholders on days without events and highlights today with dedicated markers', () => {

--- a/apps/web/src/pages/Calendar.tsx
+++ b/apps/web/src/pages/Calendar.tsx
@@ -237,6 +237,19 @@ const Calendar = () => {
     </>
   );
 
+  const WEEK_GRID_CLASSNAMES = useMemo(
+    () => [
+      'calendar-week-day--monday',
+      'calendar-week-day--tuesday',
+      'calendar-week-day--wednesday',
+      'calendar-week-day--thursday',
+      'calendar-week-day--friday',
+      'calendar-week-day--saturday',
+      'calendar-week-sunday calendar-week-day--sunday'
+    ],
+    []
+  );
+
   const renderWeekView = () => (
     <div className="calendar-week-grid" data-testid="calendar-week-grid">
       {weekDays.map((day, index) => {
@@ -255,7 +268,7 @@ const Calendar = () => {
             data-today={todayMatch ? 'true' : undefined}
             className={`calendar-week-day${selected ? ' calendar-day-selected' : ''}${
               todayMatch ? ' calendar-day-today' : ''
-            }${index === 6 ? ' calendar-week-sunday' : ''}`}
+            } ${WEEK_GRID_CLASSNAMES[index] ?? ''}`.trim()}
             aria-label={`Выбрать ${new Intl.DateTimeFormat('ru-RU', {
               weekday: 'long',
               day: 'numeric',
@@ -264,13 +277,20 @@ const Calendar = () => {
             }).format(day)}`}
             onClick={() => handleSelectDate(day)}
           >
-            <div className="calendar-week-day-header">
+            <div
+              className="calendar-week-day-caption"
+              data-caption-size="shared"
+              data-nowrap="true"
+            >
               {formatWeekdayLabel(day)}
             </div>
             <ul className="calendar-week-event-list">
               {visibleEvents.map((event) => (
                 <li key={event.id} className="calendar-week-event-item">
-                  {event.title}
+                  <span className="calendar-week-event-bullet" aria-hidden="true">
+                    •
+                  </span>
+                  <span className="calendar-week-event-text">{event.title}</span>
                 </li>
               ))}
               {remaining > 0 ? (


### PR DESCRIPTION
## Summary
- rebuild the week view grid into stacked weekday columns with a wide Sunday tile
- enforce a shared non-wrapping caption size and add bold bullets before event lines
- adjust the calendar tests to cover the new layout and bullet rendering expectations

## Testing
- npm --workspace apps/web run test -- src/pages/Calendar.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e0c4b7542483249d1c5d4b8d0bfd97