### PR TITLE
feat(calendar): add day modal with event management

### DIFF
--- a/apps/web/src/pages/Calendar.css
+++ b/apps/web/src/pages/Calendar.css
@@ -273,6 +273,216 @@
   color: var(--app-color-primary-contrast);
 }
 
+.calendar-day-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 16px;
+  z-index: 1000;
+}
+
+.calendar-day-dialog {
+  width: min(520px, 100%);
+  background: var(--app-color-surface);
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  max-height: min(680px, 90vh);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.2);
+  overflow: hidden;
+}
+
+.calendar-day-dialog-header {
+  padding: 20px 24px 12px;
+}
+
+.calendar-day-dialog-header h2 {
+  margin: 0;
+  font-size: clamp(18px, 4.5vw, 22px);
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.calendar-day-dialog-body {
+  padding: 0 24px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  overflow-y: auto;
+}
+
+.calendar-day-dialog-events {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.calendar-day-event-item {
+  display: flex;
+}
+
+.calendar-day-event-button {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  width: 100%;
+  border: none;
+  background: var(--app-color-surface-subtle);
+  border-radius: 14px;
+  padding: 12px 16px;
+  text-align: left;
+  cursor: pointer;
+  color: var(--app-color-text-primary);
+}
+
+.calendar-day-event-button:focus-visible {
+  outline: 2px solid var(--app-color-primary);
+  outline-offset: 2px;
+}
+
+.calendar-day-event-bullet {
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 1;
+  margin-top: 2px;
+}
+
+.calendar-day-event-title {
+  flex: 1;
+  font-size: 15px;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.calendar-day-event-time {
+  flex: 0 0 auto;
+  margin-left: auto;
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--app-color-text-secondary);
+  min-width: 52px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.calendar-day-event-empty {
+  text-align: center;
+  padding: 32px 16px;
+  border-radius: 12px;
+  background: var(--app-color-surface-subtle);
+  color: var(--app-color-text-secondary);
+  font-size: 15px;
+}
+
+.calendar-day-dialog-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.calendar-day-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.calendar-day-form-field label {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--app-color-text-secondary);
+}
+
+.calendar-day-form-field input {
+  border-radius: 12px;
+  border: 1px solid var(--app-color-divider);
+  padding: 10px 12px;
+  font-size: 15px;
+  color: var(--app-color-text-primary);
+}
+
+.calendar-day-form-field input:focus-visible {
+  outline: 2px solid var(--app-color-primary);
+  outline-offset: 2px;
+}
+
+.calendar-day-dialog-error {
+  color: var(--app-color-error, #dc2626);
+  font-size: 14px;
+}
+
+.calendar-day-dialog-submit {
+  align-self: flex-start;
+  border-radius: 20px;
+  border: none;
+  background: var(--app-color-primary);
+  color: var(--app-color-primary-contrast);
+  font-weight: 600;
+  padding: 10px 20px;
+  cursor: pointer;
+}
+
+.calendar-day-dialog-footer {
+  margin-top: auto;
+  padding: 16px 24px 20px;
+  border-top: 1px solid var(--app-color-divider);
+  display: flex;
+  justify-content: flex-end;
+}
+
+.calendar-day-dialog-back {
+  border-radius: 18px;
+  border: 1px solid var(--app-color-divider);
+  background: var(--app-color-surface-subtle);
+  padding: 10px 20px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.calendar-day-context-menu {
+  position: fixed;
+  min-width: 140px;
+  background: var(--app-color-surface);
+  border-radius: 12px;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.24);
+  padding: 4px;
+  z-index: 1001;
+}
+
+.calendar-day-context-menu button {
+  width: 100%;
+  border: none;
+  background: transparent;
+  padding: 10px 12px;
+  text-align: left;
+  cursor: pointer;
+  font-size: 14px;
+  border-radius: 8px;
+}
+
+.calendar-day-context-menu button:hover,
+.calendar-day-context-menu button:focus-visible {
+  background: var(--app-color-surface-subtle);
+  outline: none;
+}
+
+.calendar-day-dialog-back:focus-visible,
+.calendar-day-dialog-submit:focus-visible {
+  outline: 2px solid var(--app-color-primary);
+  outline-offset: 2px;
+}
+
+@media (min-width: 768px) {
+  .calendar-day-dialog {
+    max-height: 640px;
+  }
+}
+
 @media (min-width: 600px) {
   .calendar-year-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));


### PR DESCRIPTION
## Summary
- add a day modal that opens from month and week views to show and manage events locally
- implement backdrop, dialog, list, and context menu styling for the day card experience
- cover modal interactions, sorting, and deletion flows with focused vitest tests

## Testing
- npm --workspace apps/web run test -- src/pages/Calendar.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e0e8a7f76883248f21cb23acf43470