### PR TITLE
Align day modal layout and add tests

### DIFF
--- a/apps/web/src/pages/Calendar.css
+++ b/apps/web/src/pages/Calendar.css
@@ -297,6 +297,9 @@
 
 .calendar-day-dialog-header {
   padding: 20px 24px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .calendar-day-dialog-header h2 {
@@ -304,6 +307,13 @@
   font-size: clamp(18px, 4.5vw, 22px);
   font-weight: 700;
   text-transform: capitalize;
+}
+
+.calendar-day-dialog-subheading {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--app-color-text-secondary);
 }
 
 .calendar-day-dialog-body {
@@ -328,8 +338,9 @@
 }
 
 .calendar-day-event-button {
-  display: flex;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
   gap: 12px;
   width: 100%;
   border: none;
@@ -351,24 +362,24 @@
   font-size: 18px;
   line-height: 1;
   margin-top: 2px;
+  align-self: flex-start;
 }
 
 .calendar-day-event-title {
-  flex: 1;
   font-size: 15px;
   line-height: 1.4;
   word-break: break-word;
+  min-width: 0;
 }
 
 .calendar-day-event-time {
-  flex: 0 0 auto;
-  margin-left: auto;
   font-weight: 600;
   font-size: 14px;
   color: var(--app-color-text-secondary);
   min-width: 52px;
   text-align: right;
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .calendar-day-event-empty {
@@ -416,32 +427,44 @@
   font-size: 14px;
 }
 
-.calendar-day-dialog-submit {
-  align-self: flex-start;
-  border-radius: 20px;
+.calendar-day-time-field,
+.calendar-day-dialog-actions {
+  width: min(260px, 100%);
+  margin: 0 auto;
+}
+
+.calendar-day-dialog-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.calendar-day-dialog-action-button {
+  width: 100%;
+  border-radius: 18px;
+  padding: 10px 20px;
+  font-weight: 600;
+  cursor: pointer;
   border: none;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.calendar-day-dialog-action-button--primary {
   background: var(--app-color-primary);
   color: var(--app-color-primary-contrast);
-  font-weight: 600;
-  padding: 10px 20px;
-  cursor: pointer;
 }
 
-.calendar-day-dialog-footer {
-  margin-top: auto;
-  padding: 16px 24px 20px;
-  border-top: 1px solid var(--app-color-divider);
-  display: flex;
-  justify-content: flex-end;
-}
-
-.calendar-day-dialog-back {
-  border-radius: 18px;
-  border: 1px solid var(--app-color-divider);
+.calendar-day-dialog-action-button--secondary {
   background: var(--app-color-surface-subtle);
-  padding: 10px 20px;
-  font-weight: 600;
-  cursor: pointer;
+  color: var(--app-color-text-primary);
+  border: 1px solid var(--app-color-divider);
+}
+
+.calendar-day-dialog-action-button:focus-visible {
+  outline: 2px solid var(--app-color-primary);
+  outline-offset: 2px;
 }
 
 .calendar-day-context-menu {
@@ -469,12 +492,6 @@
 .calendar-day-context-menu button:focus-visible {
   background: var(--app-color-surface-subtle);
   outline: none;
-}
-
-.calendar-day-dialog-back:focus-visible,
-.calendar-day-dialog-submit:focus-visible {
-  outline: 2px solid var(--app-color-primary);
-  outline-offset: 2px;
 }
 
 @media (min-width: 768px) {

--- a/apps/web/src/pages/Calendar.test.tsx
+++ b/apps/web/src/pages/Calendar.test.tsx
@@ -236,6 +236,9 @@ describe('Calendar page', () => {
     let heading = within(dialog).getByRole('heading', { level: 2 });
     expect(heading.textContent).toMatch(/^[А-ЯЁ][а-яё]+, \d+ [а-яё]+$/);
     expect(heading.textContent).toContain('мая');
+    const subheading = within(dialog).getByText('Список дел');
+    expect(subheading).toBeInTheDocument();
+    expect(subheading.parentElement).toHaveClass('calendar-day-dialog-header');
 
     fireEvent.click(within(dialog).getByRole('button', { name: 'Назад' }));
 
@@ -246,6 +249,35 @@ describe('Calendar page', () => {
     heading = within(dialog).getByRole('heading', { level: 2 });
     expect(heading.textContent).toMatch(/^[А-ЯЁ][а-яё]+, \d+ [а-яё]+$/);
     expect(heading.textContent).toContain('мая');
+  });
+
+  it('centers actions, time input, and aligns event times inside the day modal', () => {
+    render(<Calendar />);
+
+    fireEvent.click(screen.getByTestId('calendar-day-2024-05-15'));
+
+    const dialog = screen.getByRole('dialog');
+    const actionsWrapper = within(dialog).getByTestId('calendar-day-dialog-actions');
+    expect(actionsWrapper.className).toBe('calendar-day-dialog-actions');
+
+    const actionButtons = within(actionsWrapper).getAllByTestId('calendar-day-dialog-action');
+    expect(actionButtons).toHaveLength(2);
+    actionButtons.forEach((button) => {
+      expect(button.className).toContain('calendar-day-dialog-action-button');
+    });
+    expect(actionButtons[0]).toHaveTextContent('+ добавить');
+    expect(actionButtons[0]).toHaveAttribute('type', 'submit');
+    expect(actionButtons[1]).toHaveTextContent('Назад');
+    expect(actionButtons[1]).toHaveAttribute('type', 'button');
+
+    const timeField = within(dialog).getByTestId('calendar-day-time-field');
+    expect(timeField.className).toBe('calendar-day-form-field calendar-day-time-field');
+
+    const [firstEvent] = within(dialog).getAllByTestId('calendar-day-event');
+    expect(firstEvent.className).toContain('calendar-day-event-button');
+    const eventTime = within(firstEvent).getByText(/\d{2}:\d{2}/);
+    expect(eventTime.className).toBe('calendar-day-event-time');
+    expect(eventTime).toHaveAttribute('data-nowrap', 'true');
   });
 
   it('adds events with 30-minute time picker and sorts items placing untimed last', () => {
@@ -263,13 +295,13 @@ describe('Calendar page', () => {
       target: { value: 'Прогулка в парке' }
     });
     fireEvent.change(timeInput, { target: { value: '10:30' } });
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Добавить' }));
+    fireEvent.click(within(dialog).getByRole('button', { name: '+ добавить' }));
 
     fireEvent.change(descriptionInput, {
       target: { value: 'Очень длинное событие без времени для проверки переноса' }
     });
     fireEvent.change(timeInput, { target: { value: '' } });
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Добавить' }));
+    fireEvent.click(within(dialog).getByRole('button', { name: '+ добавить' }));
 
     const eventButtons = within(dialog).getAllByTestId('calendar-day-event');
     const eventTexts = eventButtons.map((button) =>
@@ -306,7 +338,7 @@ describe('Calendar page', () => {
       target: { value: 'Очень длинное описание события для проверки переноса текста' }
     });
     fireEvent.change(timeInput, { target: { value: '16:30' } });
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Добавить' }));
+    fireEvent.click(within(dialog).getByRole('button', { name: '+ добавить' }));
 
     const addedButton = within(dialog)
       .getAllByTestId('calendar-day-event')

--- a/apps/web/src/pages/Calendar.tsx
+++ b/apps/web/src/pages/Calendar.tsx
@@ -650,6 +650,7 @@ const Calendar = () => {
           >
             <header className="calendar-day-dialog-header">
               <h2 id={dialogTitleId}>{formatDayDialogHeading(selectedDate)}</h2>
+              <p className="calendar-day-dialog-subheading">Список дел</p>
             </header>
             <div className="calendar-day-dialog-body">
               <ul className="calendar-day-dialog-events" data-testid="calendar-day-event-list">
@@ -680,7 +681,10 @@ const Calendar = () => {
                           <span className="calendar-day-event-title">
                             {eventItem.title}
                           </span>
-                          <span className="calendar-day-event-time">
+                          <span
+                            className="calendar-day-event-time"
+                            data-nowrap="true"
+                          >
                             {time ?? ''}
                           </span>
                         </button>
@@ -709,7 +713,10 @@ const Calendar = () => {
                     placeholder="Введите описание"
                   />
                 </div>
-                <div className="calendar-day-form-field">
+                <div
+                  className="calendar-day-form-field calendar-day-time-field"
+                  data-testid="calendar-day-time-field"
+                >
                   <label htmlFor="calendar-day-time">Время</label>
                   <input
                     id="calendar-day-time"
@@ -729,19 +736,27 @@ const Calendar = () => {
                     {formError}
                   </div>
                 ) : null}
-                <button type="submit" className="calendar-day-dialog-submit">
-                  Добавить
-                </button>
+                <div
+                  className="calendar-day-dialog-actions"
+                  data-testid="calendar-day-dialog-actions"
+                >
+                  <button
+                    type="submit"
+                    className="calendar-day-dialog-action-button calendar-day-dialog-action-button--primary"
+                    data-testid="calendar-day-dialog-action"
+                  >
+                    + добавить
+                  </button>
+                  <button
+                    type="button"
+                    className="calendar-day-dialog-action-button calendar-day-dialog-action-button--secondary"
+                    onClick={handleCloseDayModal}
+                    data-testid="calendar-day-dialog-action"
+                  >
+                    Назад
+                  </button>
+                </div>
               </form>
-            </div>
-            <div className="calendar-day-dialog-footer">
-              <button
-                type="button"
-                className="calendar-day-dialog-back"
-                onClick={handleCloseDayModal}
-              >
-                Назад
-              </button>
             </div>
           </div>
           {contextMenu && menuPosition ? (


### PR DESCRIPTION
## Summary
- add the "Список дел" subheading and center the day modal action buttons
- align the time picker with the actions and vertically center event times
- extend Calendar page tests to cover the new layout hooks and labels

## Testing
- npm --workspace apps/web run test -- src/pages/Calendar.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e0fb0861b083249a191f0bc2517f6f